### PR TITLE
Solved Issue #48 - "Basket is not deleted after checkout."

### DIFF
--- a/shop/views/checkout.py
+++ b/shop/views/checkout.py
@@ -81,4 +81,8 @@ class ThankYouView(ShopTemplateView):
         order.save()
         completed.send(sender=self, order=order)
 
+        # Empty the customers basket, to reflect that the purchase was completed
+        cart_object = get_or_create_cart(self.request)
+        cart_object.empty()
+
         return ctx


### PR DESCRIPTION
Added a method on the "thank you" page, where it also changed the order status to next level, where it deletes the cart.
