### PR TITLE
Added verbose names to address model

### DIFF
--- a/shop/addressmodel/models.py
+++ b/shop/addressmodel/models.py
@@ -18,42 +18,48 @@ State: %s,
 Country: %s
 """)
 
-ADDRESS_TEMPLATE = getattr(settings, 'SHOP_ADDRESS_TEMPLATE', BASE_ADDRESS_TEMPLATE)
+ADDRESS_TEMPLATE = getattr(settings, 'SHOP_ADDRESS_TEMPLATE',
+                           BASE_ADDRESS_TEMPLATE)
 
 class Country(models.Model):
     name = models.CharField(max_length=255)
 
     def __unicode__(self):
         return u'%s' % self.name
-    
+
     class Meta(object):
         verbose_name = _('Country')
         verbose_name_plural = _('Countries')
 
 
 class Address(models.Model):
-    user_shipping = models.OneToOneField(User, related_name='shipping_address', blank=True, null=True)
-    user_billing = models.OneToOneField(User, related_name='billing_address', blank=True, null=True)
-    
-    name = models.CharField(max_length=255)
-    address = models.CharField(max_length=255)
-    address2 = models.CharField(max_length=255,blank=True)
-    zip_code = models.CharField(max_length=20)
-    city = models.CharField(max_length=20)
-    state = models.CharField(max_length=255)
-    country = models.ForeignKey(Country, blank=True, null=True)
-    
+    user_shipping = models.OneToOneField(User, related_name='shipping_address',
+                                         blank=True, null=True)
+    user_billing = models.OneToOneField(User, related_name='billing_address',
+                                        blank=True, null=True)
+
+    name = models.CharField(_('Name'), max_length=255)
+    address = models.CharField(_('Address'), max_length=255)
+    address2 = models.CharField(_('Address2'), max_length=255, blank=True)
+    zip_code = models.CharField(_('Zip Code'), max_length=20)
+    city = models.CharField(_('City'), max_length=20)
+    state = models.CharField(_('State'), max_length=255)
+    country = models.ForeignKey(Country, verbose_name=_('Country'), blank=True,
+                                null=True)
+
     class Meta(object):
         verbose_name = _('Address')
         verbose_name_plural = _("Addresses")
-    
+
     def __unicode__(self):
         return '%s (%s, %s)' % (self.name, self.zip_code, self.city)
-        
+
     def clone(self):
-        new_kwargs = dict([(fld.name, getattr(self, fld.name)) for fld in self._meta.fields if fld.name != 'id'])
+        new_kwargs = dict([(fld.name, getattr(self, fld.name))
+                           for fld in self._meta.fields if fld.name != 'id'])
         return self.__class__.objects.create(**new_kwargs)
 
     def as_text(self):
-        return ADDRESS_TEMPLATE % (self.name, '%s\n%s' % (self.address, self.address2),
-                                   self.zip_code, self.city, self.state, self.country)
+        return ADDRESS_TEMPLATE % (
+            self.name, '%s\n%s' % (self.address, self.address2),
+            self.zip_code, self.city, self.state, self.country)


### PR DESCRIPTION
If I am not totally wrong, adding verbose_names with ugettext will also be reflected in the labels of the billing address' model form, right? This way we can make sure that the shop is ready for multilingual sites out of the box (I think we should!) without needing to override the address model just for translations.
