### PR TITLE
started refactoring in order to use app_settings.py

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -1,3 +1,13 @@
+======================
+Undocumented Settings
+======================
+
+The following settings have been found undocumented while doing a refactoring.
+We will add documentation soon. Promise :)
+
+  * SHOP_ADDRESS_TEMPLATE
+
+
 ================
 General Settings
 ================

--- a/shop/addressmodel/models.py
+++ b/shop/addressmodel/models.py
@@ -6,20 +6,8 @@ from django.contrib.auth.models import User
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
-from django.conf import settings
+from shop import app_settings as settings
 
-BASE_ADDRESS_TEMPLATE = \
-_("""
-Name: %(name)s,
-Address: %(address)s,
-Zip-Code: %(zipcode)s,
-City: %(city)s,
-State: %(state)s,
-Country: %(country)s
-""")
-
-ADDRESS_TEMPLATE = getattr(settings, 'SHOP_ADDRESS_TEMPLATE',
-                           BASE_ADDRESS_TEMPLATE)
 
 class Country(models.Model):
     name = models.CharField(max_length=255)
@@ -60,7 +48,7 @@ class Address(models.Model):
         return self.__class__.objects.create(**new_kwargs)
 
     def as_text(self):
-        return ADDRESS_TEMPLATE % {
+        return settings.ADDRESS_TEMPLATE % {
             'name':self.name, 'address': '%s\n%s' % (self.address, self.address2),
             'zipcode':self.zip_code, 'city':self.city, 'state':self.state,
             'country':self.country}

--- a/shop/admin/orderadmin.py
+++ b/shop/admin/orderadmin.py
@@ -4,6 +4,7 @@ from django.contrib.admin.options import ModelAdmin
 from django.utils.translation import ugettext_lazy as _
 from django.conf import settings
 
+from shop import app_settings as settings
 from shop.models.ordermodel import (Order, OrderItem,
         OrderExtraInfo, ExtraOrderPriceField, OrderPayment)
 
@@ -48,7 +49,5 @@ class OrderAdmin(ModelAdmin):
                 }),
             )
 
-
-ORDER_MODEL = getattr(settings, 'SHOP_ORDER_MODEL', None)
-if not ORDER_MODEL:
+if not settings.ORDER_MODEL:
     admin.site.register(Order, OrderAdmin)

--- a/shop/app_settings.py
+++ b/shop/app_settings.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+"""
+Settings for the django-shop application. For documentation please see 
+``/docs/settings.rst``.
+"""
+from django.conf import settings
+from django.utils.translation import ugettext_lazy as _
+
+
+BASE_ADDRESS_TEMPLATE = \
+_("""
+Name: %(name)s,
+Address: %(address)s,
+Zip-Code: %(zipcode)s,
+City: %(city)s,
+State: %(state)s,
+Country: %(country)s
+""")
+
+ADDRESS_TEMPLATE = getattr(settings, 'SHOP_ADDRESS_TEMPLATE',
+                           BASE_ADDRESS_TEMPLATE)
+
+ORDER_MODEL = getattr(settings, 'SHOP_ORDER_MODEL', None)
+
+CART_MODIFIERS = getattr(settings, 'SHOP_CART_MODIFIERS', None)

--- a/shop/cart/modifiers_pool.py
+++ b/shop/cart/modifiers_pool.py
@@ -3,6 +3,8 @@ from django.conf import settings
 from django.core import exceptions
 from django.utils.importlib import import_module
 
+from shop import app_settings
+
 
 class CartModifiersPool(object):
     
@@ -21,10 +23,10 @@ class CartModifiersPool(object):
         Heavily inspired by django.core.handlers.base...
         """
         result = []
-        if not getattr(settings,'SHOP_CART_MODIFIERS', None):
+        if not app_settings.CART_MODIFIERS:
             return result
-        
-        for modifier_path in settings.SHOP_CART_MODIFIERS:
+
+        for modifier_path in app_settings.CART_MODIFIERS:
             try:
                 mod_module, mod_classname = modifier_path.rsplit('.', 1)
             except ValueError:

--- a/shop/tests/utils/context_managers.py
+++ b/shop/tests/utils/context_managers.py
@@ -5,6 +5,9 @@ Borrowed from Django CMS. This is too useful to live without
 """
 from django.conf import settings
 
+from shop import app_settings
+
+
 class NULL:
     pass
 
@@ -27,6 +30,7 @@ class SettingsOverride(object):
         for key, value in self.overrides.items():
             self.old[key] = getattr(settings, key, NULL)
             setattr(settings, key, value)
+        reload(app_settings)
 
     def __exit__(self, type, value, traceback):
         for key, value in self.old.items():
@@ -34,4 +38,5 @@ class SettingsOverride(object):
                 setattr(settings, key, value)
             else:
                 delattr(settings,key) # do not pollute the context!
+        reload(app_settings)
 


### PR DESCRIPTION
Do not pull! This is just for a first codereview.

I would propose to centralize all settings that we have in django-shop into a file (i.e. app_settings.py). I believe this is regarded as a best practice for reusable apps (but maybe I am wrong).

Let's just imagine that, in the future, we introduce a setting SHOP_FOO and we need that setting at two places in the code for some reason.

Currently, at both places we would do FOO = getattr(settings, 'SHOP_FOO', True)

Let's also imagine, that later we will decide, that False would be a better default. We would then need to change two places. 

I also believe that having all settings with all their defaults in one file is cool for new developers. 

And as a nice side effect, due to this refactoring I would touch every single setting that we currently have and make sure that they all get documented in settings.rst - I already found one :)
