### PR TITLE
Fixes #97 - cache updated cart items in cart object.

### DIFF
--- a/shop/models/defaults/bases.py
+++ b/shop/models/defaults/bases.py
@@ -164,6 +164,15 @@ class BaseCart(models.Model):
         cart_item.delete()
         self.save()
 
+    def get_updated_cart_items(self):
+        """
+        Returns updated cart items after update() has been called and
+        cart modifiers have been processed for all cart items.
+        """
+        assert hasattr(self, '_updated_cart_items'),\
+                "Cart needs to be updated before calling get_updated_cart_items."
+        return self._updated_cart_items
+
     def update(self, state=None):
         """
         This should be called whenever anything is changed in the cart (added
@@ -200,7 +209,7 @@ class BaseCart(models.Model):
         for modifier in cart_modifiers_pool.get_modifiers_list():
             modifier.pre_process_cart(self, state)
 
-        for item in items: # For each OrderItem (order line)...
+        for item in items: # For each CartItem (order line)...
             item.product = products_dict[item.product_id] #This is still the ghetto select_related
             self.subtotal_price = self.subtotal_price + item.update(state)
         
@@ -217,6 +226,9 @@ class BaseCart(models.Model):
         # it is displayed
         for modifier in cart_modifiers_pool.get_modifiers_list():
             modifier.post_process_cart(self, state)
+
+        # Cache updated cart items
+        self._updated_cart_items = items
 
     def empty(self):
         """

--- a/shop/tests/cart.py
+++ b/shop/tests/cart.py
@@ -178,3 +178,20 @@ class CartTestCase(TestCase):
             # be a new CartItem being created now.
             self.cart.add_product(self.product, queryset=qs)
             self.assertEqual(len(self.cart.items.all()),2)
+
+    def test_get_updated_cart_items(self):
+        self.cart.add_product(self.product)
+        self.cart.update()
+        cached_cart_items = self.cart.get_updated_cart_items()
+
+        cart_items = CartItem.objects.filter(cart=self.cart)
+        for item in cart_items:
+            item.update({})
+
+        self.assertEqual(len(cached_cart_items), len(cart_items))
+        self.assertEqual(cached_cart_items[0].line_total,
+                cart_items[0].line_total)
+
+    def test_get_updated_cart_items_without_updating_cart(self):
+        with self.assertRaises(AssertionError):
+            self.cart.get_updated_cart_items()

--- a/shop/views/cart.py
+++ b/shop/views/cart.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from django.core.urlresolvers import reverse
 from django.http import HttpResponse, HttpResponseRedirect
-from shop.models.cartmodel import CartItem
 from shop.models.productmodel import Product
 from shop.util.cart import get_or_create_cart
 from shop.views import ShopView, ShopTemplateResponseMixin
@@ -106,13 +105,7 @@ class CartDetails(ShopTemplateResponseMixin, CartItemDetail):
         cart_object = get_or_create_cart(self.request)
         cart_object.update(state)
         ctx.update({'cart': cart_object})
-        
-        cart_items = CartItem.objects.filter(cart=cart_object)
-        final_items = []
-        for item in cart_items:
-            item.update(state)
-            final_items.append(item)
-        ctx.update({'cart_items': final_items})
+        ctx.update({'cart_items': cart_object.get_updated_cart_items()})
         
         return ctx
 


### PR DESCRIPTION
Avoid code duplication and unecessary db queries.
