### PR TITLE
Set max value on cart item form.

### DIFF
--- a/shop/forms.py
+++ b/shop/forms.py
@@ -27,7 +27,7 @@ class BillingShippingForm(forms.Form):
 class CartItemModelForm(forms.ModelForm):
     """A form for the CartItem model. To be used in the CartDetails view."""
 
-    quantity = forms.IntegerField(min_value=0)
+    quantity = forms.IntegerField(min_value=0, max_value=9999)
 
     class Meta:
         model = CartItem


### PR DESCRIPTION
When you enter 99999999999999 into the quantity fields of the cart, you will get an exception when using mysql. 

To circumvent this I put a max_value of 9999. Any objections against this? Is it very likely that a shop will want to sell more than 9999 items of the same product in one shipment? If these items each cost $99999, we will get an exception as well, because the sum has to be saved into the database as well.

Any ideas on how to tackle this problem professionally?
