### PR TITLE
Wrapped template contents in block body, added shop/base.html tmpl.

### DIFF
--- a/shop/templates/shop/base.html
+++ b/shop/templates/shop/base.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en-us">
+  <head>
+    <title>django-shop</title>
+  </head>
+  <body>
+    {% block body %}
+    {% endblock %}
+  </body>
+</html>

--- a/shop/templates/shop/cart.html
+++ b/shop/templates/shop/cart.html
@@ -1,74 +1,77 @@
+{% extends "shop/base.html" %}
 {% load i18n %}
 
-<h1>{% trans "Your shopping cart" %}</h1>
-{% if cart_items %}
+{% block body %}
+  <h1>{% trans "Your shopping cart" %}</h1>
+  {% if cart_items %}
 
-    <form method="post" action="{% url cart_update %}">
-      {% csrf_token %}
-      {{ formset.management_form }}
-      {% for form in formset %}
-        {{ form.id }}
-      {% endfor %}
-      <table border="1">
-        <thead>
-          <tr>
-          <th>{% trans "Product name" %}</th>
-          <th>{% trans "Unit price" %}</th>
-          <th>{% trans "Quantity" %}</th>
-          <th>&nbsp;</th>
-          </tr>
-        </thead>
-
-        <tbody>
-          {% for form in formset %}
-            {% with form.quantity as field %}
-              <tr>
-                <td>{{ form.instance.product.name }}</td>
-                <td>{{ form.instance.product.get_price }}</td>
-                <td>
-                    {{ field.errors }}
-                    {{ field }}</td>
-                <td>{{ form.instance.line_subtotal }}</td>
-              </tr>
-              {% for extra_price_field in form.instance.extra_price_fields %}
-                <tr>
-                  <td colspan="2">&nbsp;</td>
-                  <td>{{ extra_price_field.0 }}</td>
-                  <td>{{ extra_price_field.1 }}</td>
-                </tr>
-              {% endfor %}
-              <tr><td colspan="2">&nbsp;</td><td>{% trans "Line Total" %}:</td><td>{{ form.instance.line_total }}</td></tr>
-            {% endwith %}
-          {% endfor %}
-        </tbody>
-
-        <tfoot>
-          <tr><td colspan="2">&nbsp;</td><td>{% trans "Cart Subtotal" %}</td><td>{{cart.subtotal_price}}</td></tr>
-          {% for extra_price_field in cart.extra_price_fields %}
+      <form method="post" action="{% url cart_update %}">
+        {% csrf_token %}
+        {{ formset.management_form }}
+        {% for form in formset %}
+          {{ form.id }}
+        {% endfor %}
+        <table border="1">
+          <thead>
             <tr>
-              <td colspan="2">&nbsp;</td>
-              <td>{{ extra_price_field.0 }}</td>
-              <td>{{ extra_price_field.1 }}</td>
+            <th>{% trans "Product name" %}</th>
+            <th>{% trans "Unit price" %}</th>
+            <th>{% trans "Quantity" %}</th>
+            <th>&nbsp;</th>
             </tr>
-          {% endfor %}
-          <tr><td colspan="2">&nbsp;</td><td><b>{% trans "Cart Total" %}</b></td><td><b>{{cart.total_price}}</b></td></tr>
-        </tfoot>
-      </table>
+          </thead>
 
-      <p><input type="submit" value="{% trans "Update Shopping Cart" %}"/></p>
-    </form>
+          <tbody>
+            {% for form in formset %}
+              {% with form.quantity as field %}
+                <tr>
+                  <td>{{ form.instance.product.name }}</td>
+                  <td>{{ form.instance.product.get_price }}</td>
+                  <td>
+                      {{ field.errors }}
+                      {{ field }}</td>
+                  <td>{{ form.instance.line_subtotal }}</td>
+                </tr>
+                {% for extra_price_field in form.instance.extra_price_fields %}
+                  <tr>
+                    <td colspan="2">&nbsp;</td>
+                    <td>{{ extra_price_field.0 }}</td>
+                    <td>{{ extra_price_field.1 }}</td>
+                  </tr>
+                {% endfor %}
+                <tr><td colspan="2">&nbsp;</td><td>{% trans "Line Total" %}:</td><td>{{ form.instance.line_total }}</td></tr>
+              {% endwith %}
+            {% endfor %}
+          </tbody>
 
-    <form action="{% url cart_delete %}" method="post">
-      {% csrf_token %}
-      <p><input type="submit" value="{% trans "Empty Shopping Cart" %}"/></p>
-    </form>
+          <tfoot>
+            <tr><td colspan="2">&nbsp;</td><td>{% trans "Cart Subtotal" %}</td><td>{{cart.subtotal_price}}</td></tr>
+            {% for extra_price_field in cart.extra_price_fields %}
+              <tr>
+                <td colspan="2">&nbsp;</td>
+                <td>{{ extra_price_field.0 }}</td>
+                <td>{{ extra_price_field.1 }}</td>
+              </tr>
+            {% endfor %}
+            <tr><td colspan="2">&nbsp;</td><td><b>{% trans "Cart Total" %}</b></td><td><b>{{cart.total_price}}</b></td></tr>
+          </tfoot>
+        </table>
 
-    <p>
-      <a href="{% url checkout_selection %}">{% trans "Proceed to checkout" %}</a>
-    </p>
+        <p><input type="submit" value="{% trans "Update Shopping Cart" %}"/></p>
+      </form>
 
-{% else %}
-<p>
-  {% trans "Shopping cart is empty" %}
-</p>
-{% endif %}
+      <form action="{% url cart_delete %}" method="post">
+        {% csrf_token %}
+        <p><input type="submit" value="{% trans "Empty Shopping Cart" %}"/></p>
+      </form>
+
+      <p>
+        <a href="{% url checkout_selection %}">{% trans "Proceed to checkout" %}</a>
+      </p>
+
+  {% else %}
+  <p>
+    {% trans "Shopping cart is empty" %}
+  </p>
+  {% endif %}
+{% endblock %}

--- a/shop/templates/shop/checkout/selection.html
+++ b/shop/templates/shop/checkout/selection.html
@@ -1,15 +1,15 @@
-<html>
-<body>
-<h1>Shipping and Billing</h1>
-<form method="POST">
-{% csrf_token %}
-<h3>Your shipping address</h3>
-{{ shipping_address.as_p }}
-<h3>Your billing address</h3>
-{{ billing_address.as_p }}
-<h3>Payment and Shipping Methods</h3>
-{{ billing_shipping_form.as_p }}
-<button type="submit">Save</button>
-</form>
-</body>
-</html>
+{% extends "shop/base.html" %}
+
+{% block body %}
+  <h1>Shipping and Billing</h1>
+  <form method="POST">
+  {% csrf_token %}
+  <h3>Your shipping address</h3>
+  {{ shipping_address.as_p }}
+  <h3>Your billing address</h3>
+  {{ billing_address.as_p }}
+  <h3>Payment and Shipping Methods</h3>
+  {{ billing_shipping_form.as_p }}
+  <button type="submit">Save</button>
+  </form>
+{% endblock %}

--- a/shop/templates/shop/checkout/thank_you.html
+++ b/shop/templates/shop/checkout/thank_you.html
@@ -1,3 +1,7 @@
-<h1>Thank you for your order!</h1>
-<p>Your order has been placed</p>
-<a href="{% url shop_welcome %}">Back to the main page</a>
+{% extends "shop/base.html" %}
+
+{% block body %}
+  <h1>Thank you for your order!</h1>
+  <p>Your order has been placed</p>
+  <a href="{% url shop_welcome %}">Back to the main page</a>
+{% endblock %}

--- a/shop/templates/shop/order_detail.html
+++ b/shop/templates/shop/order_detail.html
@@ -1,6 +1,9 @@
+{% extends "shop/base.html" %}
 {% load i18n %}
 {% load shop_tags %}
 
-<h1>{{ object }}</h1>
+{% block body %}
+  <h1>{{ object }}</h1>
 
-{% order object %}
+  {% order object %}
+{% endblock %}

--- a/shop/templates/shop/order_list.html
+++ b/shop/templates/shop/order_list.html
@@ -1,12 +1,15 @@
+{% extends "shop/base.html" %}
 {% load i18n %}
 
-<h1>{% trans "Order list" %}</h1>
+{% block body %}
+  <h1>{% trans "Order list" %}</h1>
 
-<ul>
-  {% for order in object_list  %}
-  <li>
-    <a href="{{ order.get_absolute_url }}">{{ order }}</a>
-  </li>
-  {% endfor %}
-</ul>
+  <ul>
+    {% for order in object_list  %}
+    <li>
+      <a href="{{ order.get_absolute_url }}">{{ order }}</a>
+    </li>
+    {% endfor %}
+  </ul>
+{% endblock %}
 

--- a/shop/templates/shop/product_detail.html
+++ b/shop/templates/shop/product_detail.html
@@ -1,24 +1,29 @@
-<h1>Product detail:</h1>
-{{object.name}}<br />
-{{object.slug}}<br />
-{{object.short_description}}<br />
-{{object.long_description}}<br />
-{{object.active}}<br />
+{% extends "shop/base.html" %}
+{% block body %}
 
-{{object.date_added}}<br />
-{{object.last_modified}}<br />
+  <h1>Product detail:</h1>
+  {{object.name}}<br />
+  {{object.slug}}<br />
+  {{object.short_description}}<br />
+  {{object.long_description}}<br />
+  {{object.active}}<br />
 
-{{object.unit_price}}<br />
+  {{object.date_added}}<br />
+  {{object.last_modified}}<br />
 
-{% if object.category %}
-{{object.category.name}}
-{% else %}
-(Product is at root category)
-{% endif %}
-<br />
+  {{object.unit_price}}<br />
 
-<form method="post" action="{% url cart %}">{% csrf_token %}
-<input type="hidden" name="add_item_id" value="{{object.id}}">
-<input type="hidden" name="add_item_quantity" value="1">
-<input type="submit" value="Add to cart">
-</form>
+  {% if object.category %}
+  {{object.category.name}}
+  {% else %}
+  (Product is at root category)
+  {% endif %}
+  <br />
+
+  <form method="post" action="{% url cart %}">{% csrf_token %}
+  <input type="hidden" name="add_item_id" value="{{object.id}}">
+  <input type="hidden" name="add_item_quantity" value="1">
+  <input type="submit" value="Add to cart">
+  </form>
+{% endblock %}
+

--- a/shop/templates/shop/product_list.html
+++ b/shop/templates/shop/product_list.html
@@ -1,23 +1,26 @@
+{% extends "shop/base.html" %}
 
-<h1>Product list:</h1>
-<hr />
-{% for object in object_list %}
-<a href="{% url product_detail object.slug %}">{{object.name}}</a><br />
-{{object.slug}}<br />
-{{object.short_description}}<br />
-{{object.long_description}}<br />
-{{object.active}}<br />
+{% block body %}
+  <h1>Product list:</h1>
+  <hr />
+  {% for object in object_list %}
+  <a href="{% url product_detail object.slug %}">{{object.name}}</a><br />
+  {{object.slug}}<br />
+  {{object.short_description}}<br />
+  {{object.long_description}}<br />
+  {{object.active}}<br />
 
-{{object.date_added}}<br />
-{{object.last_modified}}<br />
+  {{object.date_added}}<br />
+  {{object.last_modified}}<br />
 
-{{object.unit_price}}<br />
+  {{object.unit_price}}<br />
 
-{% if object.category %}
-{{object.category.name}}<br />
-{% else %}
-(Product is at root category)<br />
-{% endif %}
-<hr />
+  {% if object.category %}
+  {{object.category.name}}<br />
+  {% else %}
+  (Product is at root category)<br />
+  {% endif %}
+  <hr />
 
-{% endfor %}
+  {% endfor %}
+{% endblock %}

--- a/shop/templates/shop/shipping/flat_rate/display_fees.html
+++ b/shop/templates/shop/shipping/flat_rate/display_fees.html
@@ -1,2 +1,6 @@
-<p>You will be charged {{shipping_costs}} for shipping</p><br />
-<a href="{% url flat_process %}">Proceed</a>
+{% extends "shop/base.html" %}
+
+{% block body %}
+  <p>You will be charged {{shipping_costs}} for shipping</p><br />
+  <a href="{% url flat_process %}">Proceed</a>
+{% endblock %}

--- a/shop/templates/shop/welcome.html
+++ b/shop/templates/shop/welcome.html
@@ -1,10 +1,14 @@
-{% load i18n %}
-<h1>Welcome to Django SHOP</h1>
+{% extends "shop/base.html" %}
 
-<a href="{% url product_list %}">Product list</a><br />
-<a href="{% url cart %}">Your cart</a><br />
+{% block body %}
+  {% load i18n %}
+  <h1>Welcome to Django SHOP</h1>
 
-{% if user.is_authenticated %}
-  {% trans "Hello" %} {{ user }}
-  <a href="{% url order_list %}">{% trans "Your orders" %}</a>
-{% endif %}
+  <a href="{% url product_list %}">Product list</a><br />
+  <a href="{% url cart %}">Your cart</a><br />
+
+  {% if user.is_authenticated %}
+    {% trans "Hello" %} {{ user }}
+    <a href="{% url order_list %}">{% trans "Your orders" %}</a>
+  {% endif %}
+{% endblock %}


### PR DESCRIPTION
Currently shipped templates does not extend any base template thus making it impossible to reuse them. 

With this patch every view template content is wrapped in `body` block and extends `shop/base.html` template.

Added is `shop/base.html` template which just create empty html document with defined `body`block. 

No other changes have been made.
