### PR TITLE
enforcing delay so that get_order_from_request really returns the latest

### DIFF
--- a/shop/tests/order.py
+++ b/shop/tests/order.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import with_statement
 from decimal import Decimal
+from time import sleep
 from django.contrib.auth.models import User
 from django.test.testcases import TestCase
 from shop.cart.modifiers_pool import cart_modifiers_pool
@@ -83,10 +84,12 @@ class OrderUtilTestCase(TestCase):
     def test_request_with_user_returns_last_order(self):
         setattr(self.request, 'user', self.user)
 
+        sleep(1) # enforce order1 to be the latest
         order1 = Order.objects.create(user=self.user)
         ret = get_order_from_request(self.request)
         self.assertEqual(ret, order1)
 
+        sleep(1) # enforce order2 to be the latest
         order2 = Order.objects.create(user=self.user)
         ret = get_order_from_request(self.request)
         self.assertEqual(ret, order2)


### PR DESCRIPTION
When adding orders on a database with a time granularity of 1 second (mysql), this test sometimes fails, because shop.util.order.get_order_from_request sorts by the 'created' timestamp which is identical.

Sorry for the messed up pull request yesterday. My master tree now is clean and in sync with the origins master. 
