### PR TITLE
Add ``data`` to extra price fields.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,11 @@
+DEV
+===
+
+* Cart modifiers can add additional text ``data`` beside ``label`` and
+  ``value`` (this data would be saved in ExtraOrderPriceField and
+  ExtraOrderItemPriceField models). This allows filtering extra order and
+  extra order item fields by some criteria.
+
 Version 0.0.13
 ==============
 

--- a/shop/cart/cart_modifiers_base.py
+++ b/shop/cart/cart_modifiers_base.py
@@ -113,6 +113,9 @@ class BaseCartModifier(object):
         a tuple. The decimal should be the amount that should get added to the
         current subtotal. It can be a negative value.
 
+        Optional third tuple element can be used to store extra text data (ie:
+        name of cart modifier, group of field, etc.).
+
         In case your modifier is based on the current price (for example in
         order to compute value added tax for this cart item only) your
         override can access that price via ``cart_item.current_total``.
@@ -122,6 +125,9 @@ class BaseCartModifier(object):
 
         And a rebate modifier would do something along the lines of:
         >>> return ('rebate', Decimal(-9))
+
+        Third tuple element can be used to store additional data:
+        >>> return ('taxes', Decimal(9), 'tax field')
 
         More examples can be found in shop.cart.modifiers.*
         """
@@ -135,6 +141,9 @@ class BaseCartModifier(object):
         ('Label', Decimal('amount')) from an override. This is expected to be
         a tuple. The decimal should be the amount that should get added to the
         current subtotal. It can be a negative value.
+
+        Optional third tuple element can be used to store extra text data (ie:
+        name of cart modifier, group of field, etc.).
 
         In case your modifier is based on the current price (for example in
         order to compute value added tax for the whole current price) your

--- a/shop/migrations/0008_auto__add_field_extraorderpricefield_data__add_field_extraorderitempri.py
+++ b/shop/migrations/0008_auto__add_field_extraorderpricefield_data__add_field_extraorderitempri.py
@@ -1,0 +1,146 @@
+# encoding: utf-8
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        
+        # Adding field 'ExtraOrderPriceField.data'
+        db.add_column('shop_extraorderpricefield', 'data', self.gf('django.db.models.fields.TextField')(default='', blank=True), keep_default=False)
+
+        # Adding field 'ExtraOrderItemPriceField.data'
+        db.add_column('shop_extraorderitempricefield', 'data', self.gf('django.db.models.fields.TextField')(default='', blank=True), keep_default=False)
+
+
+    def backwards(self, orm):
+        
+        # Deleting field 'ExtraOrderPriceField.data'
+        db.delete_column('shop_extraorderpricefield', 'data')
+
+        # Deleting field 'ExtraOrderItemPriceField.data'
+        db.delete_column('shop_extraorderitempricefield', 'data')
+
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'shop.cart': {
+            'Meta': {'object_name': 'Cart'},
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['auth.User']", 'unique': 'True', 'null': 'True', 'blank': 'True'})
+        },
+        'shop.cartitem': {
+            'Meta': {'object_name': 'CartItem'},
+            'cart': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'items'", 'to': "orm['shop.Cart']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'product': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['shop.Product']"}),
+            'quantity': ('django.db.models.fields.IntegerField', [], {})
+        },
+        'shop.extraorderitempricefield': {
+            'Meta': {'object_name': 'ExtraOrderItemPriceField'},
+            'data': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'order_item': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['shop.OrderItem']"}),
+            'value': ('django.db.models.fields.DecimalField', [], {'default': "'0.00'", 'max_digits': '12', 'decimal_places': '2'})
+        },
+        'shop.extraorderpricefield': {
+            'Meta': {'object_name': 'ExtraOrderPriceField'},
+            'data': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_shipping': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'order': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['shop.Order']"}),
+            'value': ('django.db.models.fields.DecimalField', [], {'default': "'0.00'", 'max_digits': '12', 'decimal_places': '2'})
+        },
+        'shop.order': {
+            'Meta': {'object_name': 'Order'},
+            'billing_address_text': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'order_subtotal': ('django.db.models.fields.DecimalField', [], {'default': "'0.00'", 'max_digits': '12', 'decimal_places': '2'}),
+            'order_total': ('django.db.models.fields.DecimalField', [], {'default': "'0.00'", 'max_digits': '12', 'decimal_places': '2'}),
+            'shipping_address_text': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'status': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']", 'null': 'True', 'blank': 'True'})
+        },
+        'shop.orderextrainfo': {
+            'Meta': {'object_name': 'OrderExtraInfo'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'order': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'extra_info'", 'to': "orm['shop.Order']"}),
+            'text': ('django.db.models.fields.TextField', [], {})
+        },
+        'shop.orderitem': {
+            'Meta': {'object_name': 'OrderItem'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'line_subtotal': ('django.db.models.fields.DecimalField', [], {'default': "'0.00'", 'max_digits': '12', 'decimal_places': '2'}),
+            'line_total': ('django.db.models.fields.DecimalField', [], {'default': "'0.00'", 'max_digits': '12', 'decimal_places': '2'}),
+            'order': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'items'", 'to': "orm['shop.Order']"}),
+            'product': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['shop.Product']", 'null': 'True', 'blank': 'True'}),
+            'product_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'product_reference': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'quantity': ('django.db.models.fields.IntegerField', [], {}),
+            'unit_price': ('django.db.models.fields.DecimalField', [], {'default': "'0.00'", 'max_digits': '12', 'decimal_places': '2'})
+        },
+        'shop.orderpayment': {
+            'Meta': {'object_name': 'OrderPayment'},
+            'amount': ('django.db.models.fields.DecimalField', [], {'default': "'0.00'", 'max_digits': '12', 'decimal_places': '2'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'order': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['shop.Order']"}),
+            'payment_method': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'transaction_id': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        'shop.product': {
+            'Meta': {'object_name': 'Product'},
+            'active': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'polymorphic_ctype': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'polymorphic_shop.product_set'", 'null': 'True', 'to': "orm['contenttypes.ContentType']"}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '50', 'db_index': 'True'}),
+            'unit_price': ('django.db.models.fields.DecimalField', [], {'default': "'0.00'", 'max_digits': '12', 'decimal_places': '2'})
+        }
+    }
+
+    complete_apps = ['shop']

--- a/shop/models/defaults/managers.py
+++ b/shop/models/defaults/managers.py
@@ -99,11 +99,15 @@ class OrderManager(models.Manager):
         order.save()
 
         # Let's serialize all the extra price arguments in DB
-        for label, value in cart.extra_price_fields:
+        for field in cart.extra_price_fields:
+            # data is optional
+            label, value = field[:2]
             eoi = ExtraOrderPriceField()
             eoi.order = order
             eoi.label = unicode(label)
             eoi.value = value
+            if len(field) == 3:
+                eoi.data = field[-1]
             eoi.save()
 
         # There, now move on to the order items.
@@ -121,12 +125,15 @@ class OrderManager(models.Manager):
             order_item.line_subtotal = item.line_subtotal
             order_item.save()
             # For each order item, we save the extra_price_fields to DB
-            for label, value in item.extra_price_fields:
+            for field in item.extra_price_fields:
+                label, value = field[:2]
                 eoi = ExtraOrderItemPriceField()
                 eoi.order_item = order_item
                 # Force unicode, in case it has àö...
                 eoi.label = unicode(label)
                 eoi.value = value
+                if len(field) == 3:
+                    eoi.data = field[-1]
                 eoi.save()
 
         processing.send(self.model, order=order, cart=cart)

--- a/shop/models/ordermodel.py
+++ b/shop/models/ordermodel.py
@@ -62,6 +62,7 @@ class ExtraOrderPriceField(models.Model):
     # Does this represent shipping costs?
     is_shipping = models.BooleanField(default=False, editable=False,
             verbose_name=_('Is shipping'))
+    data = models.TextField(_('Data'), blank=True)
 
     class Meta(object):
         app_label = 'shop'
@@ -77,6 +78,7 @@ class ExtraOrderItemPriceField(models.Model):
     order_item = models.ForeignKey(OrderItem, verbose_name=_('Order item'))
     label = models.CharField(max_length=255, verbose_name=_('Label'))
     value = CurrencyField(verbose_name=_('Amount'))
+    data = models.TextField(_('Data'), blank=True)
 
     class Meta(object):
         app_label = 'shop'


### PR DESCRIPTION
Cart modifiers can add additional text `data` beside `label` and   `value` (this data would be saved in ExtraOrderPriceField and   ExtraOrderItemPriceField models). 

This allows filtering and identifying extra order and extra order item fields by some criteria.

This change is full backward compatible.

I hesitated to serialize extra data as json and tried to keep things as simple as possible.
