### PR TITLE
Make sure that CartItem urls will not match the first rule EVERY time

### DIFF
--- a/shop/urls/cart.py
+++ b/shop/urls/cart.py
@@ -13,9 +13,9 @@ urlpatterns = patterns('',
         name='cart_update'),
 
     # CartItems
-    url('^item/(?P<id>[0-9A-Za-z-_.//]+)$', CartItemDetail.as_view(),
+    url('^item/(?P<id>[0-9]+)$', CartItemDetail.as_view(),
         name='cart_item'),
-    url('^item/(?P<id>[0-9A-Za-z-_.//]+)/delete$',
+    url('^item/(?P<id>[0-9]+)/delete$',
         CartItemDetail.as_view(action='delete'),
         name='cart_item_delete'),
 )


### PR DESCRIPTION
"//" was in regex causing it to match any extension after the ID.
