### PR TITLE
Replace `payed` spelling with `paid`

### DIFF
--- a/shop/models/defaults/bases.py
+++ b/shop/models/defaults/bases.py
@@ -345,17 +345,18 @@ class BaseOrder(models.Model):
     def get_absolute_url(self):
         return reverse('order_detail', kwargs={'pk': self.pk})
 
-    def is_payed(self):
-        """Has this order been integrally payed for?"""
-        return self.amount_payed == self.order_total
+    def is_paid(self):
+        """Has this order been integrally paid for?"""
+        return self.amount_paid == self.order_total
+    is_payed = is_paid #Backward compatability, deprecated spelling
 
     def is_completed(self):
         return self.status == self.COMPLETED
 
     @property
-    def amount_payed(self):
+    def amount_paid(self):
         """
-        The amount payed is the sum of related orderpayments
+        The amount paid is the sum of related orderpayments
         """
         from shop.models import OrderPayment
         sum_ = OrderPayment.objects.filter(order=self).aggregate(
@@ -364,6 +365,7 @@ class BaseOrder(models.Model):
         if not result:
             result = Decimal('-1')
         return result
+    amount_payed = amount_paid #Backward compatability, deprecated spelling
 
     @property
     def shipping_costs(self):

--- a/shop/models/ordermodel.py
+++ b/shop/models/ordermodel.py
@@ -90,7 +90,7 @@ class OrderPayment(models.Model):
     more complex payment types should they need to store more informtion
     """
     order = models.ForeignKey(Order, verbose_name=_('Order'))
-    # How much was payed with this particular transfer
+    # How much was paid with this particular transfer
     amount = CurrencyField(verbose_name=_('Amount'))
     transaction_id = models.CharField(max_length=255,
             verbose_name=_('Transaction ID'),

--- a/shop/payment/api.py
+++ b/shop/payment/api.py
@@ -31,7 +31,7 @@ class PaymentAPI(ShopAPI):
     def confirm_payment(self, order, amount, transaction_id, payment_method,
                         save=True):
         """
-        Marks the specified amount for the given order as payed.
+        Marks the specified amount for the given order as paid.
         This allows to hook in more complex behaviors (like saving a history
         of payments in a Payment model)
         The optional save argument allows backends to explicitly not save the
@@ -39,12 +39,12 @@ class PaymentAPI(ShopAPI):
         """
         OrderPayment.objects.create(
             order=order,
-            # How much was payed with this particular transfer
+            # How much was paid with this particular transfer
             amount=Decimal(amount),
             transaction_id=transaction_id,
             payment_method=payment_method)
         
-        if save and self.is_order_payed(order):
+        if save and self.is_order_paid(order):
             # Set the order status:
             order.status = Order.COMPLETED
             order.save()

--- a/shop/payment/backends/pay_on_delivery.py
+++ b/shop/payment/backends/pay_on_delivery.py
@@ -24,7 +24,7 @@ class PayOnDeliveryBackend(object):
         # Get the order object
         the_order = self.shop.get_order(request)
         # Let's mark this as being complete for the full sum in our database
-        # Set it as payed (it needs to be payed to the delivery guy, we assume
+        # Set it as paid (it needs to be paid to the delivery guy, we assume
         # he does his job properly)
         self.shop.confirm_payment(
             the_order, self.shop.get_order_total(the_order), "None",

--- a/shop/shop_api.py
+++ b/shop/shop_api.py
@@ -41,9 +41,10 @@ class ShopAPI(object):
         """
         OrderExtraInfo.objects.create(text=text, order=order)
 
-    def is_order_payed(self, order):
-        """Whether the passed order is fully payed or not."""
-        return order.is_payed()
+    def is_order_paid(self, order):
+        """Whether the passed order is fully paid or not."""
+        return order.is_paid()
+    is_order_payed = is_order_paid #Backward compatability, deprecated spelling
 
     def is_order_completed(self, order):
         return order.is_completed()

--- a/shop/tests/api.py
+++ b/shop/tests/api.py
@@ -31,9 +31,12 @@ class ShopApiTestCase(TestCase):
         oei = OrderExtraInfo.objects.get(order=self.order)
         self.assertEqual(oei.text, 'test')
 
-    def test_is_order_payed(self):
+    def test_is_order_paid(self):
         api = ShopAPI()
+        # Ensure deprecated method still works
         res = api.is_order_payed(self.order)
+        self.assertEqual(res, False)
+        res = api.is_order_paid(self.order)
         self.assertEqual(res, False)
 
     def test_is_order_complete(self):

--- a/shop/tests/order.py
+++ b/shop/tests/order.py
@@ -120,8 +120,11 @@ class OrderTestCase(TestCase):
         ret = self.order.is_completed()
         self.assertNotEqual(ret, Order.COMPLETED)
 
-    def test_is_payed_works(self):
+    def test_is_paid_works(self):
+        # Ensure deprecated method still works
         ret = self.order.is_payed()
+        self.assertEqual(ret, False)
+        ret = self.order.is_paid()
         self.assertEqual(ret, False)
 
 
@@ -307,6 +310,7 @@ class OrderPaymentTestCase(TestCase):
 
     def test_payment_sum_works(self):
         self.assertEqual(self.order.amount_payed, Decimal('-1'))
+        self.assertEqual(self.order.amount_paid, Decimal('-1'))
 
     def test_payment_sum_works_with_partial_payments(self):
         OrderPayment.objects.create(
@@ -316,6 +320,8 @@ class OrderPaymentTestCase(TestCase):
                 payment_method='test method')
         self.assertEqual(self.order.amount_payed, 2)
         self.assertEqual(self.order.is_payed(), False)
+        self.assertEqual(self.order.amount_paid, 2)
+        self.assertEqual(self.order.is_paid(), False)
 
     def test_payment_sum_works_with_full_payments(self):
         OrderPayment.objects.create(
@@ -325,3 +331,5 @@ class OrderPaymentTestCase(TestCase):
                 payment_method='test method')
         self.assertEqual(self.order.amount_payed, 10)
         self.assertEqual(self.order.is_payed(), True)
+        self.assertEqual(self.order.amount_paid, 10)
+        self.assertEqual(self.order.is_paid(), True)


### PR DESCRIPTION
"payed" is a non-standard spelling and potentially very confusing. 

This change Adds reference methods and properties so as to maintain backwards compatibility.

``` python
    def is_paid(self):
        """Has this order been integrally paid for?"""
        return self.amount_paid == self.order_total
    is_payed = is_paid #Backward compatability, deprecated spelling
```

The tests have been updated to check against both spellings.
