### PR TITLE
FIX #155 - Payment API empty cart bug

### DIFF
--- a/shop/payment/api.py
+++ b/shop/payment/api.py
@@ -7,7 +7,6 @@ new payment module or willing to use modules with another shop system.
 from decimal import Decimal
 from shop.models.ordermodel import OrderPayment
 from shop.models.ordermodel import Order
-from shop.models.cartmodel import Cart
 from shop.shop_api import ShopAPI
 from shop.order_signals import completed
 from django.core.urlresolvers import reverse
@@ -49,11 +48,6 @@ class PaymentAPI(ShopAPI):
             order.status = Order.COMPLETED
             order.save()
             completed.send(sender=self, order=order)
-    
-            # Empty the customers basket, to reflect that the purchase was
-            # completed
-            cart_object = Cart.objects.get(user=order.user)
-            cart_object.empty()
 
 
     #==========================================================================


### PR DESCRIPTION
If there is no current user, api cannot know what is cart for given order
(no request), making it impossible to empty that type of carts.

Also it does not make much sense to clear cart only if is_order_payed(order).
