### PR TITLE
Documentation clean-up. Fixed typos and grammatical mistakes.

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -20,7 +20,7 @@ The following packages are needed for the test suite to run:
 * `django_polymorphic <https://github.com/chrisglass/django_polymorphic>`_
 * `django-classy-tags <https://github.com/ojii/django-classy-tags>`_
 
-Running the following command inside your virtualenv shouldget you started::
+Running the following command inside your virtualenv should get you started::
 
     pip install django django_polymorphic django-classy-tags
 
@@ -30,8 +30,8 @@ Running the tests
 Thankfully, we provided a small yet handy script to do it for you! Simply
 invoke ``runtests.sh`` on a unix platform and you should be all set.
 
-The test suite should output normally (only "."'s), an we try to keep the suite fast 
-(subsecond), so that people can tests very often.
+The test suite should output normally (only "."'s), and we try to keep the suite fast
+(subsecond), so that people can test very often.
 
 Options
 --------
@@ -47,7 +47,7 @@ Community
 ==========
 
 Most of the discussion around django SHOP takes place on IRC (Internet Relay
-Chat), on the freenode servers in the #django-shop channel
+Chat), on the freenode servers in the #django-shop channel.
 
 We also have a mailing list and a google group::
 
@@ -56,7 +56,7 @@ We also have a mailing list and a google group::
 Code guidelines
 ================
 
-* As most projects, we try to follow :pep:`8` as closely as possible
+* Like most projects, we try to follow :pep:`8` as closely as possible
 * Most pull requests will be rejected without proper unit testing
 * Generally we like to discuss new features before they are merged in, but this
   is a somewhat flexible rule :)
@@ -66,7 +66,7 @@ Sending a pull request
 ======================
 
 We use github for development, and so all code that you would like to see
-included into should follow the following simple workflow:
+included should follow the following simple workflow:
 
 * Clone django-shop
 * Checkout your fork

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -93,7 +93,7 @@ django-cbv if you're using 1.3.
 
 .. highlight:: bash
 
-7. Most of the stuff you'll have to do is styling and templates work, so go ahead
+7. Most of the stuff you'll have to do is styling and template work, so go ahead
    and create a templates directory in your project::
    
     cd example/myshop; mkdir -p templates/myshop
@@ -137,8 +137,8 @@ describing a book::
 .. note:: The only limitation is that your product subclass must define a
    ``Meta`` class.
 
-Like a normal Django model, you might want to register it to the admin interface
-to allow easy edition by your users. In an ``admin.py`` file::
+Like a normal Django model, you might want to register it in the admin interface
+to allow for easy editing by your admin users. In an ``admin.py`` file::
 
     from django.contrib import admin
     
@@ -151,8 +151,8 @@ That's it!
 Adding taxes
 =============
 
-Adding taxes calculation according to local regulations is also something that
-you will be likely to have to do. It is relatively easy as well: create a new
+Adding tax calculations according to local regulations is also something that
+you will likely have to do. It is relatively easy as well: create a new
 file in your project, for example ``modifiers.py``, and add the following::
 
     import decimal    
@@ -181,7 +181,7 @@ add the class to the list of cart modifiers defined in your ``settings.py`` file
 Restart your server, and you should now see that a cart's total is dynamically
 augmented to reflect this new rule.
 
-You can implemented many other types of rules by overriding either this method
+You can implement many other types of rules by overriding either this method
 or other methods defined in
 :class:`~shop.cart.cart_modifiers_base.BaseCartModifier`.
 

--- a/docs/howto/how-to-extend-django-shop-models.rst
+++ b/docs/howto/how-to-extend-django-shop-models.rst
@@ -34,7 +34,7 @@ Extending the Product model in django SHOP works like this::
     SHOP_PRODUCT_MODEL = 'myproject.models.MyProduct'
 
 .. important:: Your model replacement must define a :class:`Meta` class.
-   Otherwise, they will inherit their parent's :class:`Meta`, which will break
+   Otherwise, it will inherit its parent's :class:`Meta`, which will break
    things. The :class:`Meta` class does not need to do anything important - it
    just has to be there.
     
@@ -50,4 +50,4 @@ From a django interactive shell, you should now be able to do::
 Settings
 =========
 
-All available settings to control models overrides are defined in :doc:`/settings`
+All available settings to control model overrides are defined in :doc:`/settings`

--- a/docs/howto/how-to-interact-with-the-cart.rst
+++ b/docs/howto/how-to-interact-with-the-cart.rst
@@ -2,9 +2,9 @@
 How to interact with the cart
 ===============================
 
-Interacting with the cart is most probably one of the single most important
-thing shop implementers will want to do: adding products to it, changing
-quantities...
+Interacting with the cart is probably the single most important
+thing shop implementers will want to do: e.g. adding products to it, changing
+quantities, etc...
 
 There are roughly two different ways to interact with the cart: through Ajax, or
 with more standard post-and-refresh behavior.
@@ -15,7 +15,7 @@ Updating the whole cart
 
 The normal form POST method is pretty straightforward - you simply POST to the cart's
 update URL (shop/cart/update/ by default) and pass it parameters as: update_item-<item id>=<new quantity>
-Items corresponding to the ID will be update with the new quantity
+Items corresponding to the ID will be updated with the new quantity
 
 
 Emptying the cart

--- a/docs/howto/how-to-payment.rst
+++ b/docs/howto/how-to-payment.rst
@@ -7,7 +7,7 @@ Payment backends must be listed in settings.SHOP_PAYMENT_BACKENDS
 Shop interface
 ===============
 
-While we could solve this with defining a superclass for all payment backends,
+While we could solve this by defining a superclass for all payment backends,
 the better approach to plugins is to implement inversion-of-control, and let
 the backends hold a reference to the shop instead.
 
@@ -25,10 +25,10 @@ Common with shipping
 
 .. method:: ShopPaymentAPI.get_order(request)
 
-    Returns the currently being processed order.
-    
+    Returns the order currently being processed.
+
     :param request: a Django request object
-    :rtype: a :class:`~shop.models.Order` instance
+    :rtype: an :class:`~shop.models.Order` instance
 
 .. method:: ShopPaymentAPI.add_extra_info(order, text)
 
@@ -39,7 +39,7 @@ Common with shipping
 
 .. method:: ShopPaymentAPI.is_order_payed(order)
 
-    Whether the passed order is fully payed or not
+    Whether the passed order is fully paid or not
 
     :param order: an :class:`~shop.models.Order` instance
     :rtype: :class:`bool`
@@ -100,7 +100,7 @@ Specific to payment
     payment method keeps track of what backend was used for this specific payment.
 
     :param order: an :class:`~shop.models.Order` instance
-    :param amount: the payed amount
+    :param amount: the paid amount
     :param transaction_id: the backend-specific transaction identifier
     :param save: a :class:`bool` that indicates if the changes should be committed
         to the database.
@@ -136,7 +136,7 @@ Methods
 .. method:: PaymentBackend.get_urls()
 
     should return a list of URLs (similar to urlpatterns), to be added
-    to the URL resolver when urls are loaded. Theses will be namespaced with the
+    to the URL resolver when urls are loaded. These will be namespaced with the
     url_namespace attribute by the shop system, so it shouldn't be done manually.
 
 Security

--- a/docs/howto/how-to-product.rst
+++ b/docs/howto/how-to-product.rst
@@ -66,8 +66,8 @@ That's all there is to it :)
 Using your newly created Product
 =================================
 
-Your product should behave like a normal Django model in all circumstances. You 
-should register it to admin (and create an admin class for it) like a normal 
+Your product should behave like a normal Django model in all circumstances. You
+should register it in admin (and create an admin class for it) like a normal
 model.
 
 Code wise, the following options are possible to retrieve your newly
@@ -76,21 +76,21 @@ created model::
     # This gets your model's instance the normal way, you get both your model's
     # fields and the Product fields
     o = MyProduct.objects.get(pk=...)
-    
-    # This is also possible - You retrieve a MyProduct instance, using the 
+
+    # This is also possible - You retrieve a MyProduct instance, using the
     # Product manager
     o = Product.objects.get(pk=...)
-    
+
 .. note:: This is possible thanks to the terrific django_polymorphic dependency
-          
+
 Product variations
 ====================
 
 By design, django SHOP does not include an out of the box solution to handling
-product variations (colors, sizes...), in order to let implementors create their
-own unrestricted. 
+product variations (colors, sizes...) in order to let implementors create their
+own unrestricted solutions.
 
-If you want such a pre-made solution for simple cases, we suggest you take a 
+If you want such a pre-made solution for simple cases, we suggest you take a
 look at the `shop_simplevariations`_ "add-on" application.
 
 .. _shop_simplevariations: https://github.com/chrisglass/django-shop-simplevariations

--- a/docs/howto/how-to-shipping.rst
+++ b/docs/howto/how-to-shipping.rst
@@ -7,7 +7,7 @@ How to create a shipping backend
 Shop interface
 ===============
 
-While we could solve this with defining a superclass for all shipping backends,
+While we could solve this by defining a superclass for all shipping backends,
 the better approach to plugins is to implement inversion-of-control, and let
 the backends hold a reference to the shop instead.
 
@@ -46,7 +46,7 @@ Methods
 .. method:: get_urls
 
     should return a list of URLs (similar to urlpatterns), to be added
-    to the URL resolver when urls are loaded. Theses will be namespaced with the
+    to the URL resolver when urls are loaded. These will be namespaced with the
     :attr:`url_namespace` attribute by the shop system, so it shouldn't be done manually.
 
 Security

--- a/docs/howto/how-to-use-your-own-addressmodel.rst
+++ b/docs/howto/how-to-use-your-own-addressmodel.rst
@@ -43,9 +43,9 @@ the checkout views to work::
 This is to ensure that the views take handle "attaching" the address objects to the
 User (or the session if the shopper is a guest).
 
-We recommend to add :meth:`as_text` method to your address model that 'collects' all fields
-and return them in one string. This string will be saved to order
+We recommend adding the :meth:`as_text` method to your address model. This 'collects' all fields
+and returns them in one string. This string will be saved to the order
 (to :attr:`~shop.models.Order.billing_address_text` or
 :attr:`~shop.models.Order.shipping_address_text` accordingly) during checkout view.
-    
-You are obviously free to subclass theses views and hook your own behavior.
+
+You are obviously free to subclass these views and hook in your own behavior.

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -13,10 +13,10 @@ Cart modifiers
 
 Cart modifiers are plugins that modify the cart's contents.
 
-Rough categories could be discount modules or tax modules: rules for theses modules
+Rough categories could be discount modules or tax modules: rules for these modules
 are invariant, and should be "stacked".
 
-Example: "CDs are buy two get one free this month", "orders over 500$ get a 10% 
+Example: "CDs are buy two get one free this month", "orders over $500 get a 10%
 discount"
 
 How they work
@@ -24,14 +24,14 @@ How they work
 Cart modifiers should extend the
 :class:`shop.cart.cart_modifiers_base.BaseCartModifier` class.
 
-Users must register theses filters in the settings.SHOP_PRICE_MODIFIERS settings 
-entry. Modifiers will be iterated and function in the same fashion as django 
+Users must register these filters in the settings.SHOP_PRICE_MODIFIERS settings
+entry. Modifiers will be iterated and function in the same fashion as django
 middleware classes.
 
 :class:`BaseCartModifier` defines a set of methods that implementations should
 override, and that are called for each cart item/cart when the cart's
 :meth:`update` method is called.
- 
+
 Example implementations
 ------------------------
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -16,14 +16,14 @@ SHOP_SHIPPING_BACKENDS
 =======================
 
 In a similar fashion, this must be a list of shipping backends. This list is used
-to display the end customer what shipping options are available to him/her during 
-the checkout process. 
+to display to the end customer what shipping options are available to him/her during
+the checkout process.
 
 SHOP_CART_MODIFIERS
 ====================
 
-Theses modifiers function like the django middlewares. The cart will call each of
-theses classes, in order, every time it is displayed. They are passed every item in
+These modifiers function like the django middlewares. The cart will call each of
+these classes, in order, every time it is displayed. They are passed every item in
 the cart, as well as the cart itself.
 
 SHOP_FORCE_LOGIN
@@ -53,7 +53,7 @@ Extensibility Settings
 =======================
 
 Theses settings allow developers to extend the shop's functionality by replacing
-models by their own models. More information about how to use theses settings 
+models with their own models. More information on how to use these settings
 can be found in the :doc:`/howto/how-to-extend-django-shop-models` section.
 
 SHOP_CART_MODEL

--- a/docs/signals.rst
+++ b/docs/signals.rst
@@ -56,7 +56,7 @@ Arguments sent with this signal:
 .. data:: shop.order_signals.confirmed
     :module:
 
-Emitted when the user finished placing his order (regardless of the payment
+Emitted when the user has finished placing his order (regardless of the payment
 success or failure).
 
 Arguments sent with this signal:
@@ -76,7 +76,7 @@ Arguments sent with this signal:
 .. data:: shop.order_signals.completed
     :module:
 
-Emitted when the payment was received for the :class:`~shop.models.Order`. This
+Emitted when payment is received for the :class:`~shop.models.Order`. This
 signal is emitted by the :class:`shop.views.checkout.ThankYouView`.
 
 Arguments sent with this signal:
@@ -93,7 +93,7 @@ Arguments sent with this signal:
 .. data:: shop.order_signals.cancelled
     :module:
 
-Emitted if the payment was refused or other fatal problem.
+Emitted if the payment was refused or another fatal problem occurred.
 
 Arguments sent with this signal:
 

--- a/docs/templatetags.rst
+++ b/docs/templatetags.rst
@@ -58,8 +58,8 @@ Usage
 
 If no argument is given, the tag will just render all active products. The tag
 allows an optional argument ``objects``. It should be a queryset of
-:class:`~shop.models.Product` objects. If given, the tag will render the given
-products only instead of all active products.
+:class:`~shop.models.Product` objects. If supplied, the tag will render the given
+products instead of all active products.
 
 ::
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -17,7 +17,7 @@ Installation
 Defining your products
 ======================
 
-The first thing a shop should do is defining products to sell. While some other
+The first thing a shop should do is define its products to sell. While some other
 shop solutions do not require you to, in django SHOP you must write a django
 model (or a set of django models) to represent your products.
 


### PR DESCRIPTION
I noticed quite a few typos and grammatical errors while browsing the docs so I thought I'd clean them up a little.

I'm sure this isn't all inclusive, but it should help some other readers.
