### PR TITLE
fix for tests failing on Django 1.3.1

### DIFF
--- a/shop/tests/shipping.py
+++ b/shop/tests/shipping.py
@@ -180,11 +180,11 @@ class FlatRateShippingTestCase(TestCase):
 
         # User logged in (no order)
         view = self.backend.view_process_order(self.request)
-        self.assertEqual(view.get('location'), '/')
+        self.assertEqual(view.get('location', None), '/')
 
         # User logged in with order
         order = Order()
         setattr(order, 'user', self.user)
         order.save()
         view = self.backend.view_process_order(self.request)
-        self.assertEqual(view.get('location'), reverse('checkout_payment'))
+        self.assertEqual(view.get('location', None), reverse('checkout_payment'))


### PR DESCRIPTION
HttpResponse's get method did not have a default for `alternate` in Django 1.3.1; set it to `None`.
