### PR TITLE
Replacing product "id" with "pk" for custom product model

### DIFF
--- a/shop/models_bases/__init__.py
+++ b/shop/models_bases/__init__.py
@@ -202,8 +202,8 @@ class BaseCart(models.Model):
         # This is a ghetto "select_related" for polymorphic models.
         items = CartItem.objects.filter(cart=self)
         product_ids = [item.product_id for item in items]
-        products = Product.objects.filter(id__in=product_ids)
-        products_dict = dict([(p.id, p) for p in products])
+        products = Product.objects.filter(pk__in=product_ids)
+        products_dict = dict([(p.pk, p) for p in products])
 
         self.extra_price_fields = []  # Reset the price fields
         self.subtotal_price = Decimal('0.0')  # Reset the subtotal


### PR DESCRIPTION
Replacing product "id" with "pk" in filtering on custom product model.
