### PR TITLE
send the confirmed signal

### DIFF
--- a/shop/models_bases/__init__.py
+++ b/shop/models_bases/__init__.py
@@ -10,7 +10,6 @@ from polymorphic.polymorphic_model import PolymorphicModel
 from shop.cart.modifiers_pool import cart_modifiers_pool
 from shop.util.fields import CurrencyField
 from shop.util.loader import get_model_string
-from shop.order_signals import confirmed
 import django
 
 
@@ -364,11 +363,6 @@ class BaseOrder(models.Model):
 
     def __unicode__(self):
         return _('Order ID: %(id)s') % {'id': self.pk}
-
-    def save(self, *args, **kwargs):
-        if self.status == self.CONFIRMED:
-            confirmed.send(sender=None, order=self)
-        super(BaseOrder, self).save(*args, **kwargs)
 
     def get_absolute_url(self):
         return reverse('order_detail', kwargs={'pk': self.pk})

--- a/shop/views/checkout.py
+++ b/shop/views/checkout.py
@@ -19,6 +19,7 @@ from shop.util.cart import get_or_create_cart
 from shop.util.order import add_order_to_request, get_order_from_request
 from shop.views import ShopTemplateView, ShopView
 from shop.util.login_mixin import LoginMixin
+from shop.order_signals import confirmed
 
 
 class CheckoutSelectionView(LoginMixin, ShopTemplateView):
@@ -240,6 +241,7 @@ class OrderConfirmView(RedirectView):
     def confirm_order(self):
         order = get_order_from_request(self.request)
         order.status = Order.CONFIRMED
+        confirmed.send(sender=None, order=self)
         order.save()
 
     def get(self, request, *args, **kwargs):


### PR DESCRIPTION
Here is a quick implementation of the confirmed signal. 

I am not really sure that doing it in the base_order.save() method is  the best way to do. If you happen to override this base class without subclassing it (in case of a very custom need), you will have to send the signal by yourself. It is not optimal.

However the other possibilty we currently have is to issue the signal in the
OrderConfirmView self.confirm_order() method. I am not in favor of that because if you don't have a shipping backend (which is my case) this view is not called. 

I am skipping shipping with this patch: https://github.com/divio/django-shop/pull/188

So I could also send the signal here. However this patch is a temporary solution and send the signal from two different location is not DRY.
