### PR TITLE
Update shop/templates/shop/cart.html

### DIFF
--- a/shop/templates/shop/cart.html
+++ b/shop/templates/shop/cart.html
@@ -25,6 +25,7 @@
                   <td>{{ form.instance.product.get_name }}</td>
                   <td>{{ form.instance.product.get_price }}</td>
                   <td>
+                      {{ form.id }}
                       {{ field.errors }}
                       {{ field }}</td>
                   <td>{{ form.instance.line_subtotal }}</td>


### PR DESCRIPTION
fix a `MultiValueDictKeyError at /cart/update/` when doing an `Update Shopping Cart` by providing a hidden id form field as mentioned in [Django docs](https://docs.djangoproject.com/en/1.4/topics/forms/modelforms/#using-the-formset-in-the-template). 

You can reproduce this bug by navigating to "Your cart" and trying to update some quantity on the formset.
