### PR TITLE
show the whole traceback when reraising an ImportError in loader

### DIFF
--- a/shop/util/loader.py
+++ b/shop/util/loader.py
@@ -1,4 +1,5 @@
 #-*- coding: utf-8 -*-
+import sys
 from django.conf import settings
 from django.core import exceptions
 from django.utils.importlib import import_module
@@ -46,7 +47,7 @@ def load_class(class_path, setting_name=None):
                 class_module, e, setting_name)
         else:
             txt = 'Error importing backend %s: "%s".' % (class_module, e)
-        raise exceptions.ImproperlyConfigured(txt)
+        raise exceptions.ImproperlyConfigured(txt), None, sys.exc_info()[2]
 
     try:
         clazz = getattr(mod, class_name)


### PR DESCRIPTION
Currently, `shop.util.loader` hides the origin of an `ImportError` when it reraises it as an  `ImproperlyConfigured`. This patch makes sure the whole traceback is shown, which makes it considerably easier to debug circular import errors.
