### PR TITLE
Enable customized Order short name

### DIFF
--- a/shop/models_bases/__init__.py
+++ b/shop/models_bases/__init__.py
@@ -394,6 +394,14 @@ class BaseOrder(models.Model):
             sum_ += cost.value
         return sum_
 
+    @property
+    def short_name(self):
+        """
+        A short name for the order, to be displayed on the payment processor's
+        website. Should be human-readable, as much as possible
+        """
+        return "%s-%s" % (self.pk, self.order_total)
+
     def set_billing_address(self, billing_address):
         """
         Process billing_address trying to get as_text method from address

--- a/shop/shop_api.py
+++ b/shop/shop_api.py
@@ -62,10 +62,7 @@ class ShopAPI(object):
         A short name for the order, to be displayed on the payment processor's
         website. Should be human-readable, as much as possible
         """
-        try:
-            return order.short_name
-        except AttributeError:
-            return "%s-%s" % (order.pk, order.order_total)
+        return order.short_name
 
     def get_order_unique_id(self, order):
         """


### PR DESCRIPTION
This pull makes it possible to override short name of an order, used as a payment text, implemented in shop_api.py with a custom property of the Order class.

For example:

``` python
class Order(models.Model):
(...)
    @property
    def short_name(self):
        """
        A short name for the merchant order.
        Should be human-readable, as much as possible.

        """
        return self.order_number
(...)
```
