### PR TITLE
Added a simple payment backend to be used for payments in advance

### DIFF
--- a/shop/payment/backends/prepayment.py
+++ b/shop/payment/backends/prepayment.py
@@ -34,7 +34,7 @@ class ForwardFundBackend(object):
         """
         order = self.shop.get_order(request)
         amount = self.shop.get_order_total(order)
-        transaction_id = _('Transaction %s-%s') % (date.today().strftime('%Y'), order.id)
+        transaction_id = date.today().strftime('%Y') + '%06d' % order.id
         self._create_confirmed_order(order, transaction_id)
         context = RequestContext(request, {'order': order, 'amount': amount,
             'transaction_id': transaction_id, 'next_url': self.shop.get_finished_url()})


### PR DESCRIPTION
Added a simple payment backend to be used for payments in advance, for instance to transfer money by wire.
I think this backend is that simple but generic enough, that it can be added directly to the core instead of creating its own plugin.
