### PR TITLE
ImportError when Importing from django.conf.urls.defaults when using django trunk

### DIFF
--- a/shop/payment/backends/pay_on_delivery.py
+++ b/shop/payment/backends/pay_on_delivery.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
-from django.conf.urls.defaults import patterns, url
+try:
+    from django.conf.urls import patterns, url
+except ImportError:
+    from django.conf.urls.defaults import patterns, url
 from django.http import HttpResponseRedirect
 from django.utils.translation import ugettext_lazy as _
 from shop.util.decorators import on_method, shop_login_required, order_required

--- a/shop/payment/backends/prepayment.py
+++ b/shop/payment/backends/prepayment.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 from decimal import Decimal
 from datetime import date
-from django.conf.urls.defaults import patterns, url
+try:
+    from django.conf.urls import patterns, url
+except ImportError:
+    from django.conf.urls.defaults import patterns, url
 from django.template import RequestContext
 from django.utils.translation import ugettext_lazy as _
 from django.shortcuts import render_to_response

--- a/shop/payment/urls.py
+++ b/shop/payment/urls.py
@@ -6,7 +6,10 @@ http://www.example.com/shop/pay/paypal
 http://www.example.com/shop/pay/pay-on-delivery
 ...
 """
-from django.conf.urls.defaults import patterns, include
+try:
+	from django.conf.urls import patterns, include
+except ImportError:
+	from django.conf.urls.defaults import patterns, include
 from shop.backends_pool import backends_pool
 
 

--- a/shop/shipping/backends/flat_rate.py
+++ b/shop/shipping/backends/flat_rate.py
@@ -2,7 +2,10 @@
 from decimal import Decimal
 
 from django.conf import settings
-from django.conf.urls.defaults import patterns, url
+try:
+    from django.conf.urls import patterns, url
+except ImportError:
+    from django.conf.urls.defaults import patterns, url
 from django.shortcuts import render_to_response
 from django.template import RequestContext
 from django.utils.translation import ugettext_lazy as _

--- a/shop/shipping/urls.py
+++ b/shop/shipping/urls.py
@@ -6,7 +6,10 @@ http://www.example.com/shop/ship/dhl
 http://www.example.com/shop/ship/fedex
 ...
 """
-from django.conf.urls.defaults import patterns, include
+try:
+	from django.conf.urls import patterns, include
+except ImportError:
+	from django.conf.urls.defaults import patterns, include
 from shop.backends_pool import backends_pool
 
 

--- a/shop/urls/__init__.py
+++ b/shop/urls/__init__.py
@@ -1,5 +1,9 @@
 # -*- coding: utf-8 -*-
-from django.conf.urls.defaults import patterns, include, url
+try:
+	from django.conf.urls import patterns, include, url
+except ImportError:
+	from django.conf.urls.defaults import patterns, include, url
+
 from shop.views import ShopTemplateView
 
 

--- a/shop/urls/cart.py
+++ b/shop/urls/cart.py
@@ -1,4 +1,7 @@
-from django.conf.urls.defaults import url, patterns
+try:
+    from django.conf.urls import patterns, url
+except ImportError:
+    from django.conf.urls.defaults import patterns, url
 
 from shop.views.cart import CartDetails, CartItemDetail
 

--- a/shop/urls/catalog.py
+++ b/shop/urls/catalog.py
@@ -1,4 +1,7 @@
-from django.conf.urls.defaults import patterns, url
+try:
+	from django.conf.urls import patterns, url
+except ImportError:
+	from django.conf.urls.defaults import patterns, url
 
 from shop.views import ShopListView
 from shop.views.product import ProductDetailView

--- a/shop/urls/checkout.py
+++ b/shop/urls/checkout.py
@@ -1,4 +1,7 @@
-from django.conf.urls.defaults import url, patterns
+try:
+    from django.conf.urls import patterns, url
+except ImportError:
+    from django.conf.urls.defaults import patterns, url
 from shop.util.decorators import cart_required
 
 from shop.views.checkout import (

--- a/shop/urls/order.py
+++ b/shop/urls/order.py
@@ -1,4 +1,7 @@
-from django.conf.urls.defaults import patterns, url
+try:
+	from django.conf.urls import patterns, url
+except ImportError:
+	from django.conf.urls.defaults import patterns, url
 
 from shop.views.order import OrderListView, OrderDetailView
 


### PR DESCRIPTION
django.conf.urls.defaults moved into django.conf.urls on django 1.4 and was depreciated. On current django trunk the backwards compatibility has been removed so django-shop throws an ImportError.

I've cached this error and fall back to the old style when running on 1.3.
