### PR TITLE
Drop support for Django 1.3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,7 +2,7 @@ Version NEXT
 ============
 
 * models.FloatField are now automatically localized.
-* Support for Django 1.2 dropped.
+* Support for Django 1.2 and Django 1.3 dropped.
 * Product model now has property ``can_be_added_to_cart`` which is checked before adding the product to cart
 
 * Cart modifiers can add an optional ``data`` field beside ``label`` and ``value``
@@ -56,14 +56,14 @@ Version 0.1.0
 * Made Backends internationalizable, as well as the BillingShippingForm
   thanks to the introduciton of a new optional backend_verbose_name attribute
   to backends.
-* Added order_required decorator to fix bug #84, which should be used on all 
+* Added order_required decorator to fix bug #84, which should be used on all
   payment and shipping views
 * Added cart_required decorator that checks for a cart on the checkout view #172
 * Added get_product_reference method to Product (for extensibility)
 * Cart object is not saved to database if it is empty (#147)
 * Before adding items to cart you now have to use get_or_create_cart with save=True
-* Changed spelling mistakes in methods from `payed` to `paid` on the Order 
-  model and on the API. This is potentially not backwards compatible in some 
+* Changed spelling mistakes in methods from `payed` to `paid` on the Order
+  model and on the API. This is potentially not backwards compatible in some
   border cases.
 * Added a mixin class which helps to localize model fields of type DecimalField
   in Django admin view.
@@ -71,9 +71,9 @@ Version 0.1.0
   are handled with the correct localization.
 * Order status is now directly modified in the shop API
 * CartItem URLs were too greedy, they now match less.
-* In case a user has two carts, one bound to the session and one to the user, 
+* In case a user has two carts, one bound to the session and one to the user,
   the one from the session will be used (#169)
-* Fixed circular import errors by moving base models to shop.models_bases and 
+* Fixed circular import errors by moving base models to shop.models_bases and
   base managers to shop.models_bases.managers
 
 Version 0.0.13
@@ -89,7 +89,7 @@ Version 0.0.12
   urls shubfolder.
 * Made templates extend a common base template
 * Using a dynamically generated form for the cart now to validate user input.
-  This will break your cart.html template. Please refer to the changes in 
+  This will break your cart.html template. Please refer to the changes in
   cart.html shipped by the shop to see how you can update your own template.
   Basically you need to iterate over a formset now instead of cart_items.
 * Fixed a circular import problem when user overrode their own models
@@ -114,8 +114,8 @@ Version 0.0.10
   deleting).
 * Changed the version definition mechanism. You can now: import shop;
   shop.__version__. Also, it now conforms to PEP 386
-* [API Change] Changed the payment backend API to let get_finished_url 
-  and get_cancel_url return strings instead of HttpResponse objects (this 
+* [API Change] Changed the payment backend API to let get_finished_url
+  and get_cancel_url return strings instead of HttpResponse objects (this
   was confusing)
 * Tests for the shop are now runnable from any project
 * added URL to CartItemView.delete()
@@ -143,7 +143,7 @@ Version 0.0.7
 
 * Fixed bug in the extensibility section of CartItem
 * Added complete German translations
-* Added verbose names to the Address model in order to have shipping and 
+* Added verbose names to the Address model in order to have shipping and
   billing forms that has multilingual labels.
 
 Version 0.0.6

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -5,9 +5,7 @@ Getting started
 Installation
 =============
 
-Here's the 1 minute guide to getting started with django SHOP and Django 1.2.x. 
-Instructions for Django 1.3 will follow, but basically it means you don't need
-django-cbv if you're using 1.3.
+Here's the 1 minute guide to getting started with django SHOP.
 
 .. highlight:: bash
 
@@ -19,7 +17,6 @@ django-cbv if you're using 1.3.
 2. You'll want to use virtualenv::
 
     virtualenv . ; source bin/activate
-    pip install django-cbv # only if using django<1.3
     pip install south
     pip install django-shop
     pip install jsonfield
@@ -50,10 +47,6 @@ django-cbv if you're using 1.3.
         'django.contrib.auth.middleware.AuthenticationMiddleware',
         'django.contrib.messages.middleware.MessageMiddleware',
     ] # <-- Notice how it's a square bracket (a list)? It makes life easier.
-    
-    import django # A quick and very dirty test to see if it's 1.3 yet...
-    if django.VERSION[0] < 1 or django.VERSION[1] < 3:
-        MIDDLEWARE_CLASSES.append('cbv.middleware.DeferredRenderingMiddleware')
 
 
 5. Obviously, you need to add shop and myshop to your INSTALLED_APPS too::
@@ -74,13 +67,13 @@ django-cbv if you're using 1.3.
         'shop.addressmodel', # The default Address and country models
         'myshop', # the project we just created
     ]
-    
+
 6. Make the urls.py contain the following::
 
     from shop import urls as shop_urls # <-- Add this at the top
-    
+
     # Other stuff here
-    
+
     urlpatterns = patterns('',
         # Example:
         #(r'^example/', include('example.foo.urls')),
@@ -96,14 +89,14 @@ django-cbv if you're using 1.3.
 
 7. Most of the stuff you'll have to do is styling and template work, so go ahead
    and create a templates directory in your project::
-   
+
     cd example/myshop; mkdir -p templates/myshop
-    
+
 8. Lock and load::
 
     cd .. ; python manage.py syncdb --all ; python manage.py migrate --fake
     python manage.py runserver
-    
+
 9. Point your browser and marvel at the absence of styling::
 
     x-www-browser localhost:8000/shop
@@ -117,23 +110,23 @@ Adding a custom product
 Having a shop running is a good start, but you'll probably want to add at least
 one product class that you can use to sell to clients!
 
-The process is really simple: you simply need to create a class representing 
+The process is really simple: you simply need to create a class representing
 your object in your project's ``models.py``. Let's start with a very simple model
 describing a book::
 
     from shop.models import Product
     from django.db import models
-    
+
     class Book(Product):
         # The author should probably be a foreign key in the real world, but
         # this is just an example
         author = models.CharField(max_length=255)
-        cover_picture = models.ImageField(upload_to='img/book') 
+        cover_picture = models.ImageField(upload_to='img/book')
         isbn = models.CharField(max_length=255)
 
         class Meta:
             ordering = ['author']
-        
+
 
 .. note:: The only limitation is that your product subclass must define a
    ``Meta`` class.
@@ -142,12 +135,12 @@ Like a normal Django model, you might want to register it in the admin interface
 to allow for easy editing by your admin users. In an ``admin.py`` file::
 
     from django.contrib import admin
-    
+
     from models import Book
-    
+
     admin.site.register(Book)
 
-That's it! 
+That's it!
 
 Adding taxes
 =============
@@ -156,10 +149,10 @@ Adding tax calculations according to local regulations is also something that
 you will likely have to do. It is relatively easy as well: create a new
 file in your project, for example ``modifiers.py``, and add the following::
 
-    import decimal    
+    import decimal
 
     from shop.cart.cart_modifiers_base import BaseCartModifier
-    
+
     class Fixed7PercentTaxRate(BaseCartModifier):
         """
         This will add 7% of the subtotal of the order to the total.
@@ -167,17 +160,17 @@ file in your project, for example ``modifiers.py``, and add the following::
         It is of course not very useful in the real world, but this is an
         example.
         """
-        
+
         def get_extra_cart_price_field(self, cart):
             taxes = decimal.Decimal('0.07') * cart.subtotal_price
             to_append = ('Taxes total', taxes)
             return to_append
-            
+
 You can now use this newly created tax modifier in your shop! To do so, simply
 add the class to the list of cart modifiers defined in your ``settings.py`` file::
 
     SHOP_CART_MODIFIERS = ['myshop.modifiers.Fixed7PercentTaxRate']
-    
+
 Restart your server, and you should now see that a cart's total is dynamically
 augmented to reflect this new rule.
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -4,7 +4,7 @@ Tutorial
 
 This tutorial is aimed at people new to django SHOP but already familiar with
 django. If you aren't yet, reading their excellent
-`django tutorial <https://docs.djangoproject.com/en/1.3/intro/tutorial01/>`_ is
+`django tutorial <https://docs.djangoproject.com/en/1.5/intro/tutorial01/>`_ is
 highly recommended.
 
 The steps outlined in this tutorial are meant to be followed in order.

--- a/example/myshop/payment.py
+++ b/example/myshop/payment.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 from django.http import HttpResponseRedirect
 from django.shortcuts import render_to_response
 from django.template import RequestContext

--- a/example/urls.py
+++ b/example/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import patterns, include, url
 from example.myshop.views import MyOrderConfirmView
 
 from shop import urls as shop_urls

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     platforms=['OS Independent'],
     classifiers=CLASSIFIERS,
     install_requires=[
-        'Django>=1.3',
+        'Django>=1.4',
         'django-classy-tags>=0.3.3',
         'django-polymorphic>=0.2',
         'south>=0.7.2',

--- a/shop/payment/backends/pay_on_delivery.py
+++ b/shop/payment/backends/pay_on_delivery.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 from django.http import HttpResponseRedirect
 from django.utils.translation import ugettext_lazy as _
 from shop.util.decorators import on_method, shop_login_required, order_required

--- a/shop/payment/backends/prepayment.py
+++ b/shop/payment/backends/prepayment.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from decimal import Decimal
 from datetime import date
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 from django.template import RequestContext
 from django.utils.translation import ugettext_lazy as _
 from django.shortcuts import render_to_response

--- a/shop/payment/urls.py
+++ b/shop/payment/urls.py
@@ -6,7 +6,7 @@ http://www.example.com/shop/pay/paypal
 http://www.example.com/shop/pay/pay-on-delivery
 ...
 """
-from django.conf.urls.defaults import patterns, include
+from django.conf.urls import patterns, include
 from shop.backends_pool import backends_pool
 
 

--- a/shop/shipping/backends/flat_rate.py
+++ b/shop/shipping/backends/flat_rate.py
@@ -2,7 +2,7 @@
 from decimal import Decimal
 
 from django.conf import settings
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 from django.shortcuts import render_to_response
 from django.template import RequestContext
 from django.utils.translation import ugettext_lazy as _

--- a/shop/shipping/urls.py
+++ b/shop/shipping/urls.py
@@ -6,7 +6,7 @@ http://www.example.com/shop/ship/dhl
 http://www.example.com/shop/ship/fedex
 ...
 """
-from django.conf.urls.defaults import patterns, include
+from django.conf.urls import patterns, include
 from shop.backends_pool import backends_pool
 
 

--- a/shop/tests/cart.py
+++ b/shop/tests/cart.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import with_statement
 from decimal import Decimal
 from django.contrib.auth.models import User
 from django.test.testcases import TestCase

--- a/shop/tests/cart_modifiers.py
+++ b/shop/tests/cart_modifiers.py
@@ -1,5 +1,4 @@
 #-*- coding: utf-8 -*-
-from __future__ import with_statement
 from decimal import Decimal
 from django.contrib.auth.models import User
 from django.core.exceptions import ImproperlyConfigured

--- a/shop/tests/order.py
+++ b/shop/tests/order.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import with_statement
 from decimal import Decimal
 from django.contrib.auth.models import User
 from django.test.testcases import TestCase

--- a/shop/tests/payment.py
+++ b/shop/tests/payment.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import with_statement
 from decimal import Decimal
 
 from django.contrib.auth.models import User

--- a/shop/tests/shipping.py
+++ b/shop/tests/shipping.py
@@ -1,5 +1,4 @@
 #-*- coding: utf-8 -*-
-from __future__ import with_statement
 from decimal import Decimal
 
 from django.contrib.auth.models import User

--- a/shop/urls/__init__.py
+++ b/shop/urls/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-from django.conf.urls.defaults import patterns, include, url
+from django.conf.urls import patterns, include, url
+
 from shop.views import ShopTemplateView
 
 

--- a/shop/urls/cart.py
+++ b/shop/urls/cart.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import url, patterns
+from django.conf.urls import patterns, url
 
 from shop.views.cart import CartDetails, CartItemDetail
 

--- a/shop/urls/catalog.py
+++ b/shop/urls/catalog.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 
 from shop.views import ShopListView
 from shop.views.product import ProductDetailView

--- a/shop/urls/checkout.py
+++ b/shop/urls/checkout.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import url, patterns
+from django.conf.urls import patterns, url
 from shop.util.decorators import cart_required
 
 from shop.views.checkout import (

--- a/shop/urls/order.py
+++ b/shop/urls/order.py
@@ -1,5 +1,4 @@
-from django.conf.urls.defaults import patterns, url
-
+from django.conf.urls import patterns, url
 from shop.views.order import OrderListView, OrderDetailView
 
 urlpatterns = patterns('',

--- a/shop/views/__init__.py
+++ b/shop/views/__init__.py
@@ -1,12 +1,7 @@
 # -*- coding: utf-8 -*-
 from django import VERSION as django_version
-
-if django_version[0] >= 1 and django_version[1] >= 3:  # pragma: no cover
-    from django.views.generic import (TemplateView, ListView, DetailView, View)
-    from django.views.generic.base import TemplateResponseMixin
-else:  # pragma: no cover
-    from cbv import (TemplateView, ListView, DetailView, View)  # NOQA
-    from cbv.views.base import TemplateResponseMixin  # NOQA
+from django.views.generic import (TemplateView, ListView, DetailView, View)
+from django.views.generic.base import TemplateResponseMixin
 
 
 class ShopTemplateView(TemplateView):

--- a/tests/testapp/urls.py
+++ b/tests/testapp/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import patterns, include
 
 # Uncomment the next two lines to enable the admin:
 from django.contrib import admin


### PR DESCRIPTION
- Fixed the DeprecationWarning on Django 1.5 regarding the import path for django.conf.urls
- Removed from **future** import with_statement since we now rely on Python 2.5.
- Removed use of django-cbv from the codebase.
- Updated docs.
