### PR TITLE
Allow overriding the base form class used for Addresses via a SHOP_ADDRESS_FORM setting

### DIFF
--- a/shop/views/checkout.py
+++ b/shop/views/checkout.py
@@ -19,6 +19,11 @@ from shop.util.cart import get_or_create_cart
 from shop.util.order import add_order_to_request, get_order_from_request
 from shop.views import ShopTemplateView, ShopView
 from shop.util.login_mixin import LoginMixin
+from django.conf import settings
+from shop.util.loader import load_class
+
+address_form_override = load_class(getattr(settings,
+    'SHOP_ADDRESS_FORM', 'django.forms.ModelForm'))
 
 
 class CheckoutSelectionView(LoginMixin, ShopTemplateView):
@@ -29,7 +34,8 @@ class CheckoutSelectionView(LoginMixin, ShopTemplateView):
         Returns a dynamic ModelForm from the loaded AddressModel
         """
         form_class = model_forms.modelform_factory(
-            AddressModel, exclude=['user_shipping', 'user_billing'])
+            AddressModel, exclude=['user_shipping', 'user_billing'],
+            form=address_form_override)
         return form_class
 
     def get_shipping_form_class(self):


### PR DESCRIPTION
Perhaps there is a better or cleaner way of doing this, but I couldn't find one, and all I needed was to make the State field a django.contrib.localflavor.us.forms.USStateField.  I didn't want to override the actual address model because I didn't need to change anything about the model itself, just the form, and I didn't really feel like hacking the template up when it can be done so cleanly from the form.  I also thought this might be helpful in situations where people **are** using custom address models and want more control over the form used to render them.