### PR TITLE
Add support for Travis Continuos Integration 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,8 +14,6 @@ The current state is a roughly functional and highly modular system.
 Please refer to docs/plugins.rst to figure out what plugin types are available,
 and what the do
 
-[![Build Status](https://travis-ci.org/jrief/django-shop.png)](https://travis-ci.org/jrief/django-shop)
-
 You'll find the detailed doc on
 `RTD <http://readthedocs.org/projects/django-shop/>`_
 


### PR DESCRIPTION
After each commit onto github, Travis-CI runs all unit tests and displays a nice summary as available here: https://travis-ci.org/jrief/django-shop
Now its possible to easily test against different versions of Django.
Before applying this patch, Divio shall create an account on Travis-CI and connect its profile with the current django-SHOP's master tree.
