### PR TITLE
Allow to use different a AddressModel for shipping and billing

### DIFF
--- a/shop/models/__init__.py
+++ b/shop/models/__init__.py
@@ -7,5 +7,9 @@ from shop.order_signals import *  # NOQA
 from shop.util.loader import load_class
 
 # Load the class specified by the user as the Address Model.
-AddressModel = load_class(getattr(settings, 'SHOP_ADDRESS_MODEL',
-    'shop.addressmodel.models.Address'))
+ShippingAddressModel = load_class(getattr(settings, 'SHOP_SHIPPING_ADDRESS_MODEL',
+    getattr(settings, 'SHOP_ADDRESS_MODEL',
+    'shop.addressmodel.models.Address')))
+BillingAddressModel = load_class(getattr(settings, 'SHOP_BILLING_ADDRESS_MODEL',
+    getattr(settings, 'SHOP_ADDRESS_MODEL',
+    'shop.addressmodel.models.Address')))

--- a/shop/util/address.py
+++ b/shop/util/address.py
@@ -1,6 +1,6 @@
 #-*- coding: utf-8 -*-
 from django.contrib.auth.models import AnonymousUser
-from shop.models import AddressModel
+from shop.models import ShippingAddressModel, BillingAddressModel
 
 
 #==============================================================================
@@ -18,9 +18,9 @@ def get_shipping_address_from_request(request):
         # There is a logged-in user here, but he might not have an address
         # defined.
         try:
-            shipping_address = AddressModel.objects.get(
+            shipping_address = ShippingAddressModel.objects.get(
                 user_shipping=request.user)
-        except AddressModel.DoesNotExist:
+        except ShippingAddressModel.DoesNotExist:
             shipping_address = None
     else:
         # The client is a guest - let's use the session instead.
@@ -28,7 +28,7 @@ def get_shipping_address_from_request(request):
         shipping_address = None
         session_address_id = session.get('shipping_address_id')
         if session is not None and session_address_id:
-            shipping_address = AddressModel.objects.get(pk=session_address_id)
+            shipping_address = ShippingAddressModel.objects.get(pk=session_address_id)
     return shipping_address
 
 
@@ -43,16 +43,16 @@ def get_billing_address_from_request(request):
         # There is a logged-in user here, but he might not have an address
         # defined.
         try:
-            billing_address = AddressModel.objects.get(
+            billing_address = BillingAddressModel.objects.get(
                 user_billing=request.user)
-        except AddressModel.DoesNotExist:
+        except BillingAddressModel.DoesNotExist:
             billing_address = None
     else:
         # The client is a guest - let's use the session instead.
         session = getattr(request, 'session', None)
         session_billing_id = session.get('billing_address_id')
         if session is not None and session_billing_id:
-            billing_address = AddressModel.objects.get(pk=session_billing_id)
+            billing_address = BillingAddressModel.objects.get(pk=session_billing_id)
     return billing_address
 
 

--- a/shop/views/checkout.py
+++ b/shop/views/checkout.py
@@ -8,7 +8,9 @@ from django.http import HttpResponseRedirect
 from django.views.generic import RedirectView
 
 from shop.forms import BillingShippingForm
-from shop.models import AddressModel, OrderExtraInfo
+from shop.models import (
+    ShippingAddressModel, BillingAddressModel, OrderExtraInfo
+)
 from shop.models import Order
 from shop.util.address import (
     assign_address_to_request,
@@ -24,25 +26,25 @@ from shop.util.login_mixin import LoginMixin
 class CheckoutSelectionView(LoginMixin, ShopTemplateView):
     template_name = 'shop/checkout/selection.html'
 
-    def _get_dynamic_form_class_from_factory(self):
+    def _get_dynamic_form_class_from_factory(self, model):
         """
-        Returns a dynamic ModelForm from the loaded AddressModel
+        Returns a dynamic ModelForm from the given AddressModel
         """
         form_class = model_forms.modelform_factory(
-            AddressModel, exclude=['user_shipping', 'user_billing'])
+            model, exclude=['user_shipping', 'user_billing'])
         return form_class
 
     def get_shipping_form_class(self):
         """
         Provided for extensibility.
         """
-        return self._get_dynamic_form_class_from_factory()
+        return self._get_dynamic_form_class_from_factory(ShippingAddressModel)
 
     def get_billing_form_class(self):
         """
         Provided for extensibility.
         """
-        return self._get_dynamic_form_class_from_factory()
+        return self._get_dynamic_form_class_from_factory(BillingAddressModel)
 
     def create_order_object_from_cart(self):
         """
@@ -60,8 +62,8 @@ class CheckoutSelectionView(LoginMixin, ShopTemplateView):
         """
         Initializes and handles the form for the shipping address.
 
-        AddressModel is a model of the type defined in
-        ``settings.SHOP_ADDRESS_MODEL``.
+        ShippingAddressModel is a model of the type defined in
+        ``settings.SHOP_SHIPPING_ADDRESS_MODEL``.
 
         The trick here is that we generate a ModelForm for whatever model was
         passed to us by the SHOP_ADDRESS_MODEL setting, and us this, prefixed,
@@ -90,7 +92,7 @@ class CheckoutSelectionView(LoginMixin, ShopTemplateView):
                     # The user or guest doesn't already have a favorite
                     # address. Instanciate a blank one, and use this as the
                     # default value for the form.
-                    shipping_address = AddressModel()
+                    shipping_address = ShippingAddressModel()
 
                 # Instanciate the form
                 form = form_class(instance=shipping_address, prefix="ship")
@@ -100,8 +102,8 @@ class CheckoutSelectionView(LoginMixin, ShopTemplateView):
     def get_billing_address_form(self):
         """
         Initializes and handles the form for the shipping address.
-        AddressModel is a model of the type defined in
-        ``settings.SHOP_ADDRESS_MODEL``.
+        BillingAddressModel is a model of the type defined in
+        ``settings.SHOP_BILLING_ADDRESS_MODEL``.
         """
         # Try to get the cached version first.
         form = getattr(self, '_billing_form', None)
@@ -122,7 +124,7 @@ class CheckoutSelectionView(LoginMixin, ShopTemplateView):
                     # The user or guest doesn't already have a favorite
                     # address. Instansiate a blank one, and use this as the
                     # default value for the form.
-                    billing_address = AddressModel()
+                    billing_address = BillingAddressModel()
 
                 #Instanciate the form
                 form = form_class(instance=billing_address, prefix="bill")


### PR DESCRIPTION
The setting SHOP_ADDRESS_MODEL is split in 2 settings:
SHOP_SHIPPING_ADDRESS_MODEL and SHOP_BILLING_ADDRESS_MODEL. If they're not set, they default to SHOP_ADDRESS_MODEL.