### PR TITLE
make order of the items in the cart deterministic

### DIFF
--- a/shop/models_bases/__init__.py
+++ b/shop/models_bases/__init__.py
@@ -209,7 +209,7 @@ class BaseCart(models.Model):
         from shop.models import CartItem, Product
 
         # This is a ghetto "select_related" for polymorphic models.
-        items = CartItem.objects.filter(cart=self)
+        items = CartItem.objects.filter(cart=self).order_by('pk')
         product_ids = [item.product_id for item in items]
         products = Product.objects.filter(pk__in=product_ids)
         products_dict = dict([(p.pk, p) for p in products])


### PR DESCRIPTION
Maybe it depends on the dbms you're using but with MySQL at least, the order of the items in the cart can vary from one request to another which can confuse the user.
