### PR TITLE
Make sure the checkout confirmation redirect is not a permanent one

### DIFF
--- a/shop/views/checkout.py
+++ b/shop/views/checkout.py
@@ -236,6 +236,7 @@ class CheckoutSelectionView(LoginMixin, ShopTemplateView):
 
 class OrderConfirmView(RedirectView):
     url_name = 'checkout_payment'
+    permanent = False
 
     def confirm_order(self):
         order = get_order_from_request(self.request)


### PR DESCRIPTION
Permanent redirects may be cached by the browser or a (reverse) proxy, causing
the view to be ignored. The order status then won't get updated.
