### PR TITLE
Let define a custom CartItemModelForm

### DIFF
--- a/shop/forms.py
+++ b/shop/forms.py
@@ -1,11 +1,13 @@
 #-*- coding: utf-8 -*-
 """Forms for the django-shop app."""
 from django import forms
+from django.conf import settings
 from django.forms.models import modelformset_factory
 from django.utils.translation import ugettext_lazy as _
 
 from shop.backends_pool import backends_pool
 from shop.models.cartmodel import CartItem
+from shop.util.loader import load_class
 
 
 def get_shipping_backends_choices():
@@ -49,6 +51,18 @@ class CartItemModelForm(forms.ModelForm):
         return instance
 
 
+def get_cart_item_modelform_class():
+    """
+    Return the class of the CartItem ModelForm.
+
+    The default `shop.forms.CartItemModelForm` can be overridden settings
+    ``SHOP_CART_ITEM_FORM`` parameter in settings
+    """
+    cls_name = getattr(settings, 'SHOP_CART_ITEM_FORM', 'shop.forms.CartItemModelForm')
+    cls = load_class(cls_name)
+    return cls
+
+
 def get_cart_item_formset(cart_items=None, data=None):
     """
     Returns a CartItemFormSet which can be used in the CartDetails view.
@@ -58,7 +72,7 @@ def get_cart_item_formset(cart_items=None, data=None):
     :param data: Optional POST data to be bound to this formset.
     """
     assert(cart_items is not None)
-    CartItemFormSet = modelformset_factory(CartItem, form=CartItemModelForm,
+    CartItemFormSet = modelformset_factory(CartItem, form=get_cart_item_modelform_class(),
             extra=0)
     kwargs = {'queryset': cart_items, }
     form_set = CartItemFormSet(data, **kwargs)


### PR DESCRIPTION
This PR make the default CartItemModelForm overridable in settings to customize the Form (e.g.: to add validation to quantity or other custom fields)
