### PR TITLE
Fixing signal calls

### DIFF
--- a/shop/admin/orderadmin.py
+++ b/shop/admin/orderadmin.py
@@ -59,6 +59,15 @@ class OrderAdmin(LocalizeDecimalFieldsMixin, ModelAdmin):
             order.save()
             completed.send(sender=self, order=order)
 
+    def save_related(self, request, form, formset, change):
+        super(OrderAdmin, self).save_related(request, form, formset, change)
+
+        if form.instance:
+            if not form.instance.is_completed() and form.instance.is_paid():
+                form.instance.status = Order.COMPLETED
+                form.instance.save()
+                completed.send(sender=self, order=form.instance)
+
 ORDER_MODEL = getattr(settings, 'SHOP_ORDER_MODEL', None)
 if not ORDER_MODEL:
     admin.site.register(Order, OrderAdmin)

--- a/shop/admin/orderadmin.py
+++ b/shop/admin/orderadmin.py
@@ -59,14 +59,15 @@ class OrderAdmin(LocalizeDecimalFieldsMixin, ModelAdmin):
             post_save_status = order.status
 
         super(OrderAdmin, self).save_model(request, order, form, change)
-
-        if post_save_status == Order.SHIPPED and pre_save_status != Order.SHIPPED:
-            shipped.send(sender=self, order=order)
+        
+        if change:
+            if post_save_status == Order.SHIPPED and pre_save_status != Order.SHIPPED:
+                shipped.send(sender=self, order=order)
 
     def save_related(self, request, form, formset, change):
         super(OrderAdmin, self).save_related(request, form, formset, change)
 
-        if form.instance:
+        if change:
             if form.instance.status != Order.SHIPPED:
                 if not form.instance.is_completed() and form.instance.is_paid():
                     form.instance.status = Order.COMPLETED

--- a/shop/admin/orderadmin.py
+++ b/shop/admin/orderadmin.py
@@ -3,7 +3,7 @@ from django.contrib import admin
 from django.contrib.admin.options import ModelAdmin
 from django.utils.translation import ugettext_lazy as _
 from django.conf import settings
-from shop.order_signals import completed
+from shop.order_signals import completed, shipped
 from shop.admin.mixins import LocalizeDecimalFieldsMixin
 from shop.models.ordermodel import (Order, OrderItem,
         OrderExtraInfo, ExtraOrderPriceField, OrderPayment)
@@ -53,20 +53,25 @@ class OrderAdmin(LocalizeDecimalFieldsMixin, ModelAdmin):
             )
 
     def save_model(self, request, order, form, change):
+
+        if change:
+            pre_save_status = Order.objects.get(pk=order.pk).status
+            post_save_status = order.status
+
         super(OrderAdmin, self).save_model(request, order, form, change)
-        if not order.is_completed() and order.is_paid():
-            order.status = Order.COMPLETED
-            order.save()
-            completed.send(sender=self, order=order)
+
+        if post_save_status == Order.SHIPPED and pre_save_status != Order.SHIPPED:
+            shipped.send(sender=self, order=order)
 
     def save_related(self, request, form, formset, change):
         super(OrderAdmin, self).save_related(request, form, formset, change)
 
         if form.instance:
-            if not form.instance.is_completed() and form.instance.is_paid():
-                form.instance.status = Order.COMPLETED
-                form.instance.save()
-                completed.send(sender=self, order=form.instance)
+            if form.instance.status != Order.SHIPPED:
+                if not form.instance.is_completed() and form.instance.is_paid():
+                    form.instance.status = Order.COMPLETED
+                    form.instance.save()
+                    completed.send(sender=self, order=form.instance)
 
 ORDER_MODEL = getattr(settings, 'SHOP_ORDER_MODEL', None)
 if not ORDER_MODEL:


### PR DESCRIPTION
I think I have found an issue, or I think so.

If I modify from the admin view the amount of a OrderPayment, the order status is not changed and the "completed" signal is not sent. This is because the save_model method runs before the related objects are saved, therefore order.is_paid() is False. I have moved that code to the save_related method, this way it works.

I have also noticed that the "shipped" signal was not been sent, I have added the code to save_model, in case the state changes from another to "SHIPPED", the signal is called.

Please, tell me if I'm right, It's my first time with django-shop :)
