### PR TITLE
Add BaseCart.is_empty property to enable override

### DIFF
--- a/shop/models_bases/__init__.py
+++ b/shop/models_bases/__init__.py
@@ -265,6 +265,10 @@ class BaseCart(models.Model):
         """
         return sum([ci.quantity for ci in self.items.all()])
 
+    @property
+    def is_empty(self):
+        return self.total_quantity == 0
+
 
 class BaseCartItem(models.Model):
     """

--- a/shop/tests/cart.py
+++ b/shop/tests/cart.py
@@ -210,3 +210,8 @@ class CartTestCase(TestCase):
         self.cart.add_product(self.inactive_product)
         self.cart.update(self.request)
         self.assertEqual(len(self.cart.items.all()), 1)
+
+    def test_cart_with_product_is_not_empty(self):
+        self.assertTrue(self.cart.is_empty)
+        self.cart.add_product(self.product)
+        self.assertFalse(self.cart.is_empty)

--- a/shop/util/cart.py
+++ b/shop/util/cart.py
@@ -43,7 +43,7 @@ def get_or_create_cart(request, save=False):
             if session_cart and session_cart.user == request.user:
                 # and the session cart already belongs to us, we are done
                 cart = session_cart
-            elif session_cart and session_cart.total_quantity > 0 and session_cart.user != request.user:
+            elif session_cart and not session_cart.is_empty and session_cart.user != request.user:
                 # if it does not belong to us yet
                 database_cart = get_cart_from_database(request)
                 if database_cart:


### PR DESCRIPTION
It is used in get_or_create_cart() function to decide
if cart from session should be used or new cart should be created.
