### PR TITLE
Added check that an order exists in OrderConfirmView

### DIFF
--- a/shop/views/checkout.py
+++ b/shop/views/checkout.py
@@ -240,8 +240,10 @@ class OrderConfirmView(RedirectView):
 
     def confirm_order(self):
         order = get_order_from_request(self.request)
-        order.status = Order.CONFIRMED
-        order.save()
+        if order:
+            # Confirm the order, if there is one
+            order.status = Order.CONFIRMED
+            order.save()
 
     def get(self, request, *args, **kwargs):
         self.confirm_order()


### PR DESCRIPTION
The `OrderConfirmView` assumes that there is an order set on the request.  This isn't necessarily the case, and if there isn't it triggers a server error:

    'NoneType' object has no attribute 'status'

This is a slightly difficult bug to spot, as if it works the first time for a user/developer then it sets a permanent redirect to the next stage of the payment.  I was able to reproduce it by visiting the correct url using a private browsing window in Firefox.