### PR TITLE
Context gets swallowed, update it instead.

### DIFF
--- a/shop/templatetags/shop_tags.py
+++ b/shop/templatetags/shop_tags.py
@@ -40,9 +40,8 @@ class Order(InclusionTag):
         )
 
     def get_context(self, context, order):
-        return {
-            'order': order
-        }
+        context.update({'order': order, })
+        return context
 register.tag(Order)
 
 


### PR DESCRIPTION
I ran into it trying to access request in order template.