### PR TITLE
In OrderConfirmView, use self.pattern_name instead of self.url

### DIFF
--- a/shop/views/checkout.py
+++ b/shop/views/checkout.py
@@ -235,7 +235,7 @@ class CheckoutSelectionView(LoginMixin, ShopTemplateView):
 
 
 class OrderConfirmView(RedirectView):
-    url_name = 'checkout_payment'
+    pattern_name = 'checkout_payment'
     permanent = False
 
     def confirm_order(self):
@@ -248,7 +248,6 @@ class OrderConfirmView(RedirectView):
         return super(OrderConfirmView, self).get(request, *args, **kwargs)
 
     def get_redirect_url(self, **kwargs):
-        self.url = reverse(self.url_name)
         return super(OrderConfirmView, self).get_redirect_url(**kwargs)
 
 class ThankYouView(LoginMixin, ShopTemplateView):


### PR DESCRIPTION
This fixes the OrderConfirmView to use `pattern_name` instead of `self.url`.
The reason behind this is that Django will apply percent-sign formatting on the `url` attribute, and if it contains special characters, Python will crash on this. See this:

    # I have accented letters in my URLs. I use "reverse" to fetch it, thus it contains URL-escaped characters.
    # Inside my view;
    class MyView(RedirectView)
        url = reverse('my-other-view') # returns '/r%C3%A9vision/', the URL-escaped form of "révision"


    # from django/views/generic/base.py:170
    self.get_redirect_url():
        ...
        if self.url:
            url = self.url % kwargs # Fails hard because Python cannot figure out how to handle the invalid format specifiers (%C and %A)