### PR TITLE
Small tweaks

### DIFF
--- a/docs/OLD-out-of-date/snippets/modules.py
+++ b/docs/OLD-out-of-date/snippets/modules.py
@@ -13,7 +13,7 @@ def autodiscover():
 
     import copy
     from django.conf import settings
-    from django.utils.importlib import import_module
+    from importlib import import_module
     from django.utils.module_loading import module_has_submodule
 
     for app in settings.INSTALLED_APPS:

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ setup(
         'Django>=1.4',
         'django-classy-tags>=0.3.3',
         'django-polymorphic>=0.2',
-        'south>=0.7.2',
         'jsonfield>=0.9.6'
     ],
     packages=find_packages(exclude=["example", "example.*"]),

--- a/shop/addressmodel/admin.py
+++ b/shop/addressmodel/admin.py
@@ -19,5 +19,5 @@ class AddressAdmin(ModelAdmin):
     raw_id_fields = ('user_shipping', 'user_billing')
 
 
-admin.site.register(Address, AddressAdmin)
+#admin.site.register(Address, AddressAdmin)
 admin.site.register(Country, CountryAdmin)

--- a/shop/addressmodel/models.py
+++ b/shop/addressmodel/models.py
@@ -12,9 +12,9 @@ BASE_ADDRESS_TEMPLATE = \
 _("""
 Name: %(name)s,
 Address: %(address)s,
-Zip-Code: %(zipcode)s,
 City: %(city)s,
 State: %(state)s,
+Zip-Code: %(zipcode)s,
 Country: %(country)s
 """)
 
@@ -42,9 +42,9 @@ class Address(models.Model):
     name = models.CharField(_('Name'), max_length=255)
     address = models.CharField(_('Address'), max_length=255)
     address2 = models.CharField(_('Address2'), max_length=255, blank=True)
-    zip_code = models.CharField(_('Zip Code'), max_length=20)
     city = models.CharField(_('City'), max_length=20)
     state = models.CharField(_('State'), max_length=255)
+    zip_code = models.CharField(_('Zip Code'), max_length=20)
     country = models.ForeignKey(Country, verbose_name=_('Country'), blank=True,
                                 null=True)
 
@@ -64,8 +64,8 @@ class Address(models.Model):
         return ADDRESS_TEMPLATE % {
             'name': self.name,
             'address': '%s\n%s' % (self.address, self.address2),
-            'zipcode': self.zip_code,
             'city': self.city,
             'state': self.state,
+            'zipcode': self.zip_code,
             'country': self.country,
         }

--- a/shop/addressmodel/models.py
+++ b/shop/addressmodel/models.py
@@ -10,12 +10,12 @@ from django.conf import settings
 
 BASE_ADDRESS_TEMPLATE = \
 _("""
-Name: %(name)s,
-Address: %(address)s,
-City: %(city)s,
-State: %(state)s,
-Zip-Code: %(zipcode)s,
-Country: %(country)s
+%(name)s,
+%(address)s,
+%(city)s,
+%(state)s,
+%(zipcode)s,
+%(country)s
 """)
 
 ADDRESS_TEMPLATE = getattr(settings, 'SHOP_ADDRESS_TEMPLATE',

--- a/shop/addressmodel/models.py
+++ b/shop/addressmodel/models.py
@@ -41,7 +41,7 @@ class Address(models.Model):
 
     name = models.CharField(_('Name'), max_length=255)
     address = models.CharField(_('Address'), max_length=255)
-    address2 = models.CharField(_('Address2'), max_length=255, blank=True)
+    address2 = models.CharField(_('Address Cont.'), max_length=255, blank=True)
     city = models.CharField(_('City'), max_length=20)
     state = models.CharField(_('State'), max_length=255)
     zip_code = models.CharField(_('Zip Code'), max_length=20)

--- a/shop/admin/orderadmin.py
+++ b/shop/admin/orderadmin.py
@@ -54,10 +54,10 @@ class OrderAdmin(LocalizeDecimalFieldsMixin, ModelAdmin):
 
     def save_model(self, request, order, form, change):
         super(OrderAdmin, self).save_model(request, order, form, change)
-        if not order.is_completed() and order.is_paid():
-            order.status = Order.COMPLETED
-            order.save()
-            completed.send(sender=self, order=order)
+        #if not order.is_completed() and order.is_paid():
+        #    order.status = Order.COMPLETED
+        #    order.save()
+        #    completed.send(sender=self, order=order)
 
 ORDER_MODEL = getattr(settings, 'SHOP_ORDER_MODEL', None)
 if not ORDER_MODEL:

--- a/shop/cart/modifiers_pool.py
+++ b/shop/cart/modifiers_pool.py
@@ -1,7 +1,7 @@
 #-*- coding: utf-8 -*-
 from django.conf import settings
 from django.core import exceptions
-from django.utils.importlib import import_module
+from importlib import import_module
 
 
 class CartModifiersPool(object):

--- a/shop/payment/api.py
+++ b/shop/payment/api.py
@@ -9,7 +9,7 @@ from shop.models import Cart
 from shop.models.ordermodel import OrderPayment
 from shop.models.ordermodel import Order
 from shop.shop_api import ShopAPI
-from shop.order_signals import completed
+from shop.order_signals import completed, cancelled
 from django.core.urlresolvers import reverse
 
 class PaymentAPI(ShopAPI):
@@ -58,6 +58,11 @@ class PaymentAPI(ShopAPI):
 
             completed.send(sender=self, order=order)
 
+    def cancel_payment(self, order, amount, payment_method, save=True):
+        if save:
+            order.status= Order.CANCELLED
+            order.save()
+        cancelled.send(sender=self, order=order)
 
     #==========================================================================
     # URLS
@@ -81,4 +86,5 @@ class PaymentAPI(ShopAPI):
         A helper for backends to let them redirect to a generic "order was
         cancelled" URL of their choosing.
         """
-        return reverse('checkout_payment')
+
+        return reverse('payment_error')

--- a/shop/util/loader.py
+++ b/shop/util/loader.py
@@ -2,7 +2,7 @@
 import sys
 from django.conf import settings
 from django.core import exceptions
-from django.utils.importlib import import_module
+from importlib import import_module
 
 
 CLASS_PATH_ERROR = 'django-shop is unable to interpret settings value for %s. '\


### PR DESCRIPTION
First, thanks for a great shop module. I made some changes to suit my usage that I thought would be generically applicable. 

Starting with the one I'm  least confident about, I've gone about removing South as a dependency. However, a more finessed approach is probably warranted such that users who haven't migrated to 1.8 still get the necessary dependencies. 

I removed deprecated references to importlib. There again, some additional testing might be warranted to ensure non-1.8 users don't experience a regression. 

Finally, I re-ordered the Address model fields so the checkout form renders them in the order that users expect, i..e street, city, state, zip ordering. 