### PR TITLE
Issue 311

### DIFF
--- a/shop/models/customer.py
+++ b/shop/models/customer.py
@@ -75,12 +75,11 @@ class CustomerManager(models.Manager):
         """
         Decode a compact session key back to its original length and base.
         """
-        compact_session_key = compact_session_key
         base_length = len(cls.BASE64_ALPHABET)
         n = 0
         for c in compact_session_key:
             n = n * base_length + cls.REVERSE_ALPHABET[c]
-        return cls._encode(n, cls.BASE36_ALPHABET)
+        return cls._encode(n, cls.BASE36_ALPHABET).zfill(32)
 
     @classmethod
     def _encode(cls, n, base_alphabet):

--- a/testshop/test_customer.py
+++ b/testshop/test_customer.py
@@ -10,7 +10,7 @@ from rest_framework.test import APIRequestFactory
 from shop.rest.auth import PasswordResetSerializer
 from shop.models.defaults.customer import Customer
 from shop.middleware import CustomerMiddleware
-from shop.models.customer import VisitingCustomer
+from shop.models.customer import VisitingCustomer, CustomerManager
 
 
 class CustomerTest(TestCase):
@@ -189,6 +189,20 @@ class CustomerTest(TestCase):
         self.assertEqual(simpsons.count(), 0)
         with self.assertRaises(FieldDoesNotExist):
             qs.filter(no_attrib='foo')
+
+
+class SessionKeyEncodingTest(TestCase):
+
+    def test_decode_inverses_encode_if_leading_zero(self):
+        # Regression test for issue #311.
+        # We want ``decode_session_key(encode_session_key(x)) == x`` for all x.
+        # This was not the case if x started with ``0``.
+        manager = CustomerManager()
+        key = "0abc"
+        self.assertEqual(
+            manager.decode_session_key(manager.encode_session_key(key)),
+            key
+        )
 
 
 class PasswordResetSerializerTest(TestCase):

--- a/testshop/test_customer.py
+++ b/testshop/test_customer.py
@@ -198,11 +198,8 @@ class SessionKeyEncodingTest(TestCase):
         # We want ``decode_session_key(encode_session_key(x)) == x`` for all x.
         # This was not the case if x started with ``0``.
         manager = CustomerManager()
-        key = "0abc"
-        self.assertEqual(
-            manager.decode_session_key(manager.encode_session_key(key)),
-            key
-        )
+        key = "00" + 30 * "a"
+        self.assertEqual(key, manager.decode_session_key(manager.encode_session_key(key)))
 
 
 class PasswordResetSerializerTest(TestCase):


### PR DESCRIPTION
This fixes issue #311 by zero-padding the key on decoding.

I also removed the line `compact_session_key = compact_session_key` since it seems to serve no purpose. Maybe this was a leftover from an earlier version of the code.