### PR TITLE
Relax the minimum django-select2 version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         'django-fsm>=2.2.1',
         'djangorestframework>=3.1,<3.2',
         'django-angular>=0.8.1',
-        'django-select2>=5.5.0',
+        'django-select2>=4.3',
         'django-sass-processor>=0.3.4',
     ],
 )


### PR DESCRIPTION
The current djangocms-link release 1.7.2 requires django-select2 < 5.0, and we
should try to be compatible with djangocms-link.