### PR TITLE
Rest auth requirement

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,11 @@
 Changelog for djangoSHOP
 ========================
 
+0.9.2
+=====
+* Bugfix: declared django-rest-auth as requirement in setup.py.
+
+
 0.9.1
 =====
 

--- a/setup.py
+++ b/setup.py
@@ -48,5 +48,6 @@ setup(
         'django-angular>=0.8.1',
         'django-select2>=5.5.0',
         'django-sass-processor>=0.3.4',
+        'django-rest-auth>=0.5.0',
     ],
 )


### PR DESCRIPTION
We import from django-rest-auth in some places, so we should declare it as a dependency in setup.py.