### PR TITLE
Fix issue #340

### DIFF
--- a/shop/money/money_maker.py
+++ b/shop/money/money_maker.py
@@ -131,6 +131,9 @@ class AbstractMoney(Decimal):
             return Decimal().__ge__(other)
         return Decimal.__ge__(self, other)
 
+    def __deepcopy__(self, memo):
+        return self.__class__(self._cents)
+
     @classproperty
     def currency(cls):
         """


### PR DESCRIPTION
This is a naive attempt to fix issue #340.

As far as I understand, implementing the `__deepcopy__()` method is the right thing to do. However, I have not yet checked which of our attributes we have to deepcopy. 

https://docs.python.org/2/library/copy.html

>If the __deepcopy__() implementation needs to make a deep copy of a component, it should call the deepcopy() function with the component as first argument and the memo dictionary as second argument.

@jrief, please review.