### PR TITLE
Avoid showing ``cms_pages`` twice in the product admin

### DIFF
--- a/shop/admin/product.py
+++ b/shop/admin/product.py
@@ -27,6 +27,13 @@ class CMSPageAsCategoryMixin(object):
         if not hasattr(self.model, 'cms_pages'):
             raise ImproperlyConfigured("Product model requires a field named `cms_pages`")
 
+    def get_fields(self, request, obj=None):
+        # We add ``cms_pages`` in ``get_fieldsets()``, so we remove it here to
+        # avoid showing it twice.
+        fields = super(CMSPageAsCategoryMixin, self).get_fields(request, obj)
+        fields.remove('cms_pages')
+        return fields
+
     def get_fieldsets(self, request, obj=None):
         fieldsets = list(super(CMSPageAsCategoryMixin, self).get_fieldsets(request, obj=obj))
         fieldsets.append((_("Categories"), {'fields': ('cms_pages',)}),)


### PR DESCRIPTION
If the user does not explicitly define the fields or fieldsets for their
product admin class, they will end up with the M2M widget for ``cms_pages``
being displayed twice. This does not occur in our demo shops, because there we
explicitly set ``fieldsets``. This commit changes the behavior of
CMSPageAsCategoryMixin so it removes the existing ``cms_pages`` field.