### PR TITLE
Compatiblity with DRF >= 3.4.2

### DIFF
--- a/shop/rest/renderers.py
+++ b/shop/rest/renderers.py
@@ -13,15 +13,13 @@ class CMSPageRenderer(renderers.TemplateHTMLRenderer):
     are not compatible with this renderer.
     """
     def render(self, data, accepted_media_type=None, context=None):
-        request = context.pop('request')
-        response = context.pop('response')
-        context.pop('args')
-        context.pop('kwargs')
+        request = context['request']
+        response = context['response']
 
         if response.exception:
             template = self.get_exception_template(response)
         else:
-            view = context.pop('view')
+            view = context['view']
             template_names = self.get_template_names(response, view)
             template = self.resolve_template(template_names)
             context['paginator'] = view.paginator
@@ -29,5 +27,10 @@ class CMSPageRenderer(renderers.TemplateHTMLRenderer):
             context['edit_mode'] = request.current_page.publisher_is_draft
 
         context['data'] = data
-        context = self.resolve_context(context, request, response)
-        return template.render(context, request=request)
+        try:
+            # DRF >= 3.4.2
+            template_context = self.get_template_context(data, context)
+        except AttributeError:
+            # Fallback for DRF < 3.4.2
+            template_context = self.resolve_context(context, request, response)
+        return template.render(template_context, request=request)


### PR DESCRIPTION
This fixes CMSPageRenderer to be compatible with DRF >= 3.4.2.