### PR TITLE
Fail with ValidationError (rather than 500) if user does not exist

### DIFF
--- a/shop/views/checkout.py
+++ b/shop/views/checkout.py
@@ -89,6 +89,8 @@ class CheckoutViewSet(BaseViewSet):
         cart = self.get_queryset()
         if cart is None:
             raise ValidationError("Can not purchase without a cart")
+        if request.customer.user.id is None:
+            raise ValidationError("Can not purchase without a user")
         cart.update(request)
         cart.save()
 

--- a/shop/views/checkout.py
+++ b/shop/views/checkout.py
@@ -87,10 +87,8 @@ class CheckoutViewSet(BaseViewSet):
         any placeholder field.
         """
         cart = self.get_queryset()
-        if cart is None:
+        if cart.pk is None:
             raise ValidationError("Can not purchase without a cart")
-        if request.customer.user.id is None:
-            raise ValidationError("Can not purchase without a user")
         cart.update(request)
         cart.save()
 


### PR DESCRIPTION
This fixes a 500 if a client hits `/shop/api/checkout/purchase/` before the corresponding user exists in the database. The bug does not affect legitimate users, but bots sometimes hit that endpoint directly.