### PR TITLE
added post_process_cart_item to cart modifiers

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,7 +12,7 @@ Changelog for django-SHOP
 * If an anonymous customer logs in, his current cart is merged with a cart, which has previously
   been created. This has been adopted to re-use the method Product.is_in_cart()
   in and finds it's Merge the contents of the other cart into this one, afterwards delete it.
-
+* Added method ``post_process_cart_item`` to the Cart Modifiers.
 
 0.9.3
 =====

--- a/shop/models/cart.py
+++ b/shop/models/cart.py
@@ -206,6 +206,8 @@ class BaseCart(with_metaclass(deferred.ForeignKeyBuilder, models.Model)):
 
         # Iterate over the registered modifiers, to process the cart's summary
         for modifier in cart_modifiers_pool.get_all_modifiers():
+            for item in items:
+                modifier.post_process_cart_item(self, item, request)
             modifier.process_cart(self, request)
 
         # This calls the post_process_cart method from cart modifiers, if any.

--- a/shop/modifiers/base.py
+++ b/shop/modifiers/base.py
@@ -81,6 +81,12 @@ class BaseCartModifier(object):
         """
         self.add_extra_cart_item_row(cart_item, request)
 
+    def post_process_cart_item(self, cart, item, request):
+        """
+        This will be called for every line item in the Cart, while finally processing the Cart.
+        It may be used to collect the computed line totals for each modifier.
+        """
+
     def process_cart(self, cart, request):
         """
         This will be called once per Cart, after every line item was treated by method


### PR DESCRIPTION
this modifier is invoked just before invoking process_cart and can be useful to summarize data computed by ``pre_process_cart_item`` and/or ``process_cart_item``.