### PR TITLE
Add a DRF filter backend for recursively getting products from CMS pages

### DIFF
--- a/example/tests/test_rest/test_filters.py
+++ b/example/tests/test_rest/test_filters.py
@@ -1,0 +1,70 @@
+import mock
+import cms.api
+from cms.models import Page
+from django.core.exceptions import ImproperlyConfigured
+from django.test import RequestFactory, TestCase
+
+from shop.rest.filters import RecursiveCMSPagesFilterBackend
+from myshop.models.polymorphic.product import Product, ProductPage
+from myshop.models.manufacturer import Manufacturer
+
+
+def create_page(name):
+    page = cms.api.create_page(name, "INHERIT", "en")
+    page.site_id = 1
+    page.save()
+    page.publish("en")
+    page = page.get_public_object()
+    return page
+
+
+class RecursiveCMSPagesFilterBackendTest(TestCase):
+
+    def setUp(self):
+        self.manufacturer = Manufacturer.objects.create(name='Testmanufacturer')
+        self.root = create_page("root")
+        self.sibling = create_page("sibling")
+        self.child = create_page("child")
+        self.grandchild = create_page("grandchild")
+        self.grandchild.move(target=self.child, pos="first-child")
+        self.child.move(target=self.root, pos="first-child")
+
+    def _create_product(self, slug):
+        return Product.objects.create(product_name=slug, slug=slug, order=1, manufacturer=self.manufacturer)
+
+    def test_products_on_child_and_grandchild(self):
+        product = self._create_product("testproduct")
+        product2 = self._create_product("testproduct2")
+        ProductPage.objects.create(product=product, page=self.child)
+        ProductPage.objects.create(product=product2, page=self.grandchild)
+
+        request = RequestFactory().get('/')
+        request.current_page = Page.objects.get(title_set__title="root", publisher_is_draft=False)
+        view = mock.Mock(cms_pages_fields=['cms_pages'])
+
+        queryset = Product.objects.all()
+        backend = RecursiveCMSPagesFilterBackend()
+
+        self.assertEqual(backend.filter_queryset(request, queryset, view).count(), 2)
+
+    def test_product_on_sibling(self):
+        product = self._create_product("testproduct")
+        ProductPage.objects.create(product=product, page=self.sibling)
+
+        request = RequestFactory().get('/')
+        request.current_page = self.root
+        view = mock.Mock(cms_pages_fields=['cms_pages'])
+
+        queryset = Product.objects.all()
+        backend = RecursiveCMSPagesFilterBackend()
+
+        self.assertEqual(backend.filter_queryset(request, queryset, view).count(), 0)
+
+    def test_checks_cms_pages_fields(self):
+        request = RequestFactory().get('/')
+        view = mock.Mock(cms_pages_fields='not-a-list-or-tuple')
+        queryset = Product.objects.all()
+
+        backend = RecursiveCMSPagesFilterBackend()
+        self.assertRaises(ImproperlyConfigured,
+                          lambda: backend.filter_queryset(request, queryset, view))

--- a/shop/rest/filters.py
+++ b/shop/rest/filters.py
@@ -8,7 +8,14 @@ from django.db.models import Q
 from rest_framework.filters import BaseFilterBackend
 
 
-class _CMSPagesFilterBackend(BaseFilterBackend):
+class CMSPagesFilterBackend(BaseFilterBackend):
+
+    cms_pages_fields = ['cms_pages', ]
+
+    def _get_filtered_queryset(self, current_page, queryset):
+        filter_by_cms_page = (Q((field, current_page)) for field in self.cms_pages_fields)
+        return queryset.filter(reduce(operator.or_, filter_by_cms_page)).distinct()
+
     def filter_queryset(self, request, queryset, view):
         """
         Restrict queryset to entities which have one ore more relations to one or more CMS pages.
@@ -20,19 +27,12 @@ class _CMSPagesFilterBackend(BaseFilterBackend):
         current_page = request.current_page
         if current_page.publisher_is_draft:
             current_page = current_page.publisher_public
-        filter_by_cms_page = (Q((field, current_page)) for field in cms_pages_fields)
-        queryset = queryset.filter(reduce(operator.or_, filter_by_cms_page)).distinct()
-        return queryset
+        return self._get_filtered_queryset(current_page, queryset)
 
 
-class CMSPagesFilterBackend(type):
-    """
-    Class builder to filter by CMS pages.
-    A class returned by this backend, shall be added to filter_backends, when CMS pages are
-    used to emulate product categories.
-    """
-    def __new__(cls, cms_pages_fields=('cms_pages',)):
-        bases = (_CMSPagesFilterBackend,)
-        attrs = {'cms_pages_fields': cms_pages_fields}
-        new_class = type(cls.__name__, bases, attrs)
-        return new_class
+class RecursiveCMSPagesFilterBackend(CMSPagesFilterBackend):
+
+    def _get_filtered_queryset(self, current_page, queryset):
+        pages = current_page.get_descendants(include_self=True)
+        filter_by_cms_page = (Q((field + "__in", pages)) for field in self.cms_pages_fields)
+        return queryset.filter(reduce(operator.or_, filter_by_cms_page)).distinct()

--- a/shop/rest/filters.py
+++ b/shop/rest/filters.py
@@ -9,6 +9,9 @@ from rest_framework.filters import BaseFilterBackend
 
 
 class CMSPagesFilterBackend(BaseFilterBackend):
+    """
+    Use this backend to only show products assigned to the current page.
+    """
 
     cms_pages_fields = ['cms_pages', ]
 
@@ -17,9 +20,6 @@ class CMSPagesFilterBackend(BaseFilterBackend):
         return queryset.filter(reduce(operator.or_, filter_by_cms_page)).distinct()
 
     def filter_queryset(self, request, queryset, view):
-        """
-        Restrict queryset to entities which have one ore more relations to one or more CMS pages.
-        """
         cms_pages_fields = getattr(view, 'cms_pages_fields', self.cms_pages_fields)
         if not isinstance(cms_pages_fields, (list, tuple)):
             msg = "`cms_pages_fields` must be a list or tuple of fields referring to djangoCMS pages."
@@ -31,6 +31,9 @@ class CMSPagesFilterBackend(BaseFilterBackend):
 
 
 class RecursiveCMSPagesFilterBackend(CMSPagesFilterBackend):
+    """
+    Use this backend to show products assigned to the current page or any of its descendants.
+    """
 
     def _get_filtered_queryset(self, current_page, queryset):
         pages = current_page.get_descendants(include_self=True)

--- a/shop/views/catalog.py
+++ b/shop/views/catalog.py
@@ -71,14 +71,14 @@ class CMSPageProductListView(ProductListView):
     belong to which CMS page.
     """
     renderer_classes = (CMSPageRenderer, JSONRenderer, BrowsableAPIRenderer)
-    filter_backends = [CMSPagesFilterBackend()] + list(api_settings.DEFAULT_FILTER_BACKENDS)
+    filter_backends = [CMSPagesFilterBackend] + list(api_settings.DEFAULT_FILTER_BACKENDS)
     cms_pages_fields = ('cms_pages',)
 
     def get_renderer_context(self):
         renderer_context = super(ProductListView, self).get_renderer_context()
         if self.filter_class and renderer_context['request'].accepted_renderer.format == 'html':
             # restrict to products associated to this CMS page only
-            backend = CMSPagesFilterBackend()
+            backend = CMSPagesFilterBackend
             queryset = backend().filter_queryset(self.request, self.get_queryset(), self)
             if callable(getattr(self.filter_class, 'get_render_context', None)):
                 renderer_context['filter'] = self.filter_class.get_render_context(self.request, queryset)

--- a/shop/views/catalog.py
+++ b/shop/views/catalog.py
@@ -78,8 +78,8 @@ class CMSPageProductListView(ProductListView):
         renderer_context = super(ProductListView, self).get_renderer_context()
         if self.filter_class and renderer_context['request'].accepted_renderer.format == 'html':
             # restrict to products associated to this CMS page only
-            backend = CMSPagesFilterBackend
-            queryset = backend().filter_queryset(self.request, self.get_queryset(), self)
+            backend = CMSPagesFilterBackend()
+            queryset = backend.filter_queryset(self.request, self.get_queryset(), self)
             if callable(getattr(self.filter_class, 'get_render_context', None)):
                 renderer_context['filter'] = self.filter_class.get_render_context(self.request, queryset)
             elif isinstance(getattr(self.filter_class, 'render_context', None), dict):


### PR DESCRIPTION
This implements a feature requested in #359.

It also changes the way the backend class is obtained. Instead of calling a metaclass, we now just reference the backend class directly. The list of fields referencing CMS pages can be set as an attribute on the view (as before), or as an attribute on a custom subclass.