### PR TITLE
Add Maltsev, merge translators and contributors, sort

### DIFF
--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -13,9 +13,10 @@ CONTRIBUTORS
 * Aleš Kocjančič
 * Anders Petersson
 * Andrés Reyes Monge
+* Arturo Fernandez
 * Audrey Roy
-* Ben Lopatin
 * Benjamin Wohlwend
+* Ben Lopatin
 * Bojan Mihelac
 * Chris Morgan
 * Dino Perovic
@@ -29,9 +30,13 @@ CONTRIBUTORS
 * Justin Steward
 * Kristian Øllegaard
 * maltitco
+* Maltsev Artyom
 * Martin Ogden
 * Mike Yumatov
+* Mikhail Kolesnik
 * Pavel Zhukov
+* Pavel Zhukov
+* Pedro Gracia
 * Per Rosengren
 * Raúl Cumplido
 * Roberth Solís
@@ -41,14 +46,6 @@ CONTRIBUTORS
 * Sławomir Ehlert
 * Stephen Muss
 * Thomas Woolford
-
-TRANSLATORS
-===========
-
-* Mikhail Kolesnik (Russian)
-* Pavel Zhukov (Russian)
-* Pedro Gracia (Spanish)
-* Arturo Fernandez (Spanish)
 
 RETIRED CORE DEVELOPERS
 =======================

--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -35,7 +35,6 @@ CONTRIBUTORS
 * Mike Yumatov
 * Mikhail Kolesnik
 * Pavel Zhukov
-* Pavel Zhukov
 * Pedro Gracia
 * Per Rosengren
 * Raúl Cumplido


### PR DESCRIPTION
Proposal: We don't have to differentiate between contributors and translators. If anyone wants to know what exactly someone contributed, they can always use the Git history.

If we merge this PR, we can discard #471.