### PR TITLE
Make CustomerManager#get_or_create_from_request idempotent

### DIFF
--- a/shop/models/customer.py
+++ b/shop/models/customer.py
@@ -191,9 +191,13 @@ class CustomerManager(models.Manager):
             username = self.encode_session_key(request.session.session_key)
             # create an inactive intermediate user, which later can declare himself as
             # guest, or register as a valid Django user
-            user = get_user_model().objects.create_user(username)
-            user.is_active = False
-            user.save()
+            try:
+                user = get_user_model().objects.get(username=username)
+            except get_user_model().DoesNotExist:
+                user = get_user_model().objects.create_user(username)
+                user.is_active = False
+                user.save()
+
             recognized = CustomerState.UNRECOGNIZED
         customer, created = self.get_or_create(user=user, recognized=recognized)
         return customer

--- a/shop/models/customer.py
+++ b/shop/models/customer.py
@@ -189,8 +189,8 @@ class CustomerManager(models.Manager):
                 request.session.cycle_key()
                 assert request.session.session_key
             username = self.encode_session_key(request.session.session_key)
-            # create an inactive intermediate user, which later can declare himself as
-            # guest, or register as a valid Django user
+            # create or get a previously created inactive intermediate user,
+            # which later can declare himself as guest, or register as a valid Django user
             try:
                 user = get_user_model().objects.get(username=username)
             except get_user_model().DoesNotExist:


### PR DESCRIPTION
The method name `get_or_create_from_request` implies that if a customer already exists, it just returns the existing customer. This fails however, if called multiple times, as the user of the customer is always created.

Maybe the preferred way to avoid that is:
```
if request.customer.is_visitor():
    request.customer = CustomerModel.objects.get_or_create_from_request(request)
```

 But it should still be possible to just call the method multiple times.
