### PR TITLE
Deferred tests

### DIFF
--- a/example/tests/test_deferred.py
+++ b/example/tests/test_deferred.py
@@ -1,0 +1,165 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from django.db import models
+from django.test import TestCase
+from shop import deferred
+
+import six
+
+
+def create_regular_class(name, fields={}):
+    class Meta:
+        app_label = 'foo'
+
+    return type(str(name), (models.Model,), dict(Meta=Meta, __module__=__name__, **fields))
+
+
+def create_deferred_base_class(name, fields={}):
+    class Meta:
+        app_label = 'foo'
+        abstract = True
+
+    return type(
+        str(name),
+        (six.with_metaclass(deferred.ForeignKeyBuilder, models.Model),),
+        dict(Meta=Meta, __module__=__name__, **fields),
+    )
+
+
+def create_deferred_class(name, base, fields={}):
+    class Meta:
+        app_label = 'bar'
+
+    return type(str(name), (base,), dict(Meta=Meta, __module__=__name__, **fields))
+
+
+RegularUser = create_regular_class('RegularUser')
+DeferredBaseUser = create_deferred_base_class('DeferredBaseUser')
+DeferredUser = create_deferred_class('DeferredUser', DeferredBaseUser)
+
+
+RegularCustomer = create_regular_class('RegularCustomer', {
+    'user': models.OneToOneField(RegularUser, on_delete=models.PROTECT),
+    'advertised_by': models.ForeignKey('self', null=True, blank=True, on_delete=models.SET_NULL),
+})
+DeferredBaseCustomer = create_deferred_base_class('DeferredBaseCustomer', {
+    'user': deferred.OneToOneField(DeferredBaseUser, on_delete=models.PROTECT),
+    'advertised_by': deferred.ForeignKey('self', null=True, blank=True, on_delete=models.SET_NULL),
+})
+DeferredCustomer = create_deferred_class('DeferredCustomer', DeferredBaseCustomer)
+
+
+RegularProduct = create_regular_class('RegularProduct')
+DeferredBaseProduct = create_deferred_base_class('DeferredBaseProduct')
+DeferredProduct = create_deferred_class('DeferredProduct', DeferredBaseProduct)
+
+
+RegularOrder = create_regular_class('RegularOrder', {
+    'customer': models.ForeignKey(RegularCustomer, on_delete=models.PROTECT),
+    'items_simple': models.ManyToManyField(RegularProduct),
+    'items_through': models.ManyToManyField('RegularProduct', through='RegularOrderItem'),
+})
+DeferredBaseOrder = create_deferred_base_class('DeferredBaseOrder', {
+    'customer': deferred.ForeignKey(DeferredBaseCustomer, on_delete=models.PROTECT),
+    'items_simple': deferred.ManyToManyField(DeferredBaseProduct),
+    'items_through': deferred.ManyToManyField('DeferredBaseProduct', through='DeferredBaseOrderItem'),
+})
+DeferredOrder = create_deferred_class('DeferredOrder', DeferredBaseOrder)
+
+
+RegularOrderItem = create_regular_class('RegularOrderItem', {
+    'order': models.ForeignKey(RegularOrder, on_delete=models.CASCADE),
+    'product': models.ForeignKey(RegularProduct, on_delete=models.PROTECT),
+})
+DeferredBaseOrderItem = create_deferred_base_class('DeferredBaseOrderItem', {
+    'order': deferred.ForeignKey(DeferredBaseOrder, on_delete=models.CASCADE),
+    'product': deferred.ForeignKey(DeferredBaseProduct, on_delete=models.PROTECT),
+})
+DeferredOrderItem = create_deferred_class('DeferredOrderItem', DeferredBaseOrderItem)
+
+
+class DeferredTestCase(TestCase):
+
+    def _test_foreign_key(self, order_class, customer_class):
+        customer_field = order_class._meta.get_field('customer')
+
+        self.assertTrue(customer_field.is_relation)
+        self.assertTrue(customer_field.many_to_one)
+        self.assertIs(customer_field.related_model, customer_class)
+
+    def test_foreign_key_regular(self):
+        self._test_foreign_key(RegularOrder, RegularCustomer)
+
+    def test_foreign_key_deferred(self):
+        self._test_foreign_key(DeferredOrder, DeferredCustomer)
+
+    def _test_one_to_one_field(self, customer_class, user_class):
+        user_field = customer_class._meta.get_field('user')
+
+        self.assertTrue(user_field.is_relation)
+        self.assertTrue(user_field.one_to_one)
+        self.assertIs(user_field.related_model, user_class)
+
+    def test_one_to_one_field_regular(self):
+        self._test_one_to_one_field(RegularCustomer, RegularUser)
+
+    def test_one_to_one_field_deferred(self):
+        self._test_one_to_one_field(DeferredCustomer, DeferredUser)
+
+    def _test_many_to_may_field_simple(self, order_class, product_class):
+        items_field = order_class._meta.get_field('items_simple')
+
+        self.assertTrue(items_field.is_relation)
+        self.assertTrue(items_field.many_to_many)
+        self.assertIs(items_field.related_model, product_class)
+
+        m2m_field_name = items_field.m2m_field_name()
+        m2m_field = items_field.rel.through._meta.get_field(m2m_field_name)
+        m2m_reverse_field_name = items_field.m2m_reverse_field_name()
+        m2m_reverse_field = items_field.rel.through._meta.get_field(m2m_reverse_field_name)
+
+        self.assertIs(m2m_field.related_model, order_class)
+        self.assertIs(m2m_reverse_field.related_model, product_class)
+
+    def test_many_to_many_field_simple_regular(self):
+        self._test_many_to_may_field_simple(RegularOrder, RegularProduct)
+
+    def test_many_to_many_field_simple_deferred(self):
+        self._test_many_to_may_field_simple(DeferredOrder, DeferredProduct)
+
+    def _test_many_to_may_field_through(self, order_class, product_class, order_item_class):
+        items_field = order_class._meta.get_field('items_through')
+
+        self.assertTrue(items_field.is_relation)
+        self.assertTrue(items_field.many_to_many)
+        self.assertIs(items_field.related_model, product_class)
+        self.assertIs(items_field.rel.through, order_item_class)
+
+        m2m_field_name = items_field.m2m_field_name()
+        m2m_field = items_field.rel.through._meta.get_field(m2m_field_name)
+        m2m_reverse_field_name = items_field.m2m_reverse_field_name()
+        m2m_reverse_field = items_field.rel.through._meta.get_field(m2m_reverse_field_name)
+
+        self.assertIs(m2m_field.related_model, order_class)
+        self.assertIs(m2m_reverse_field.related_model, product_class)
+
+    def test_many_to_many_field_through_regular(self):
+        self._test_many_to_may_field_through(RegularOrder, RegularProduct, RegularOrderItem)
+
+    def test_many_to_many_field_through_deferred(self):
+        self._test_many_to_may_field_through(DeferredOrder, DeferredProduct, DeferredOrderItem)
+
+    def _test_foreign_key_self(self, customer_class):
+        advertised_by_field = customer_class._meta.get_field('advertised_by')
+
+        self.assertTrue(advertised_by_field.is_relation)
+        self.assertTrue(advertised_by_field.many_to_one)
+        self.assertIs(advertised_by_field.related_model, customer_class)
+
+    def test_foreign_key_self_regular(self):
+        self._test_foreign_key_self(RegularCustomer)
+
+    def test_foreign_key_self_deferred(self):
+        self._test_foreign_key_self(DeferredCustomer)

--- a/example/tests/test_deferred.py
+++ b/example/tests/test_deferred.py
@@ -12,14 +12,14 @@ import six
 
 def create_regular_class(name, fields={}, meta={}):
     meta.setdefault('app_label', 'foo')
-    Meta = type(b'Meta', (), meta)
+    Meta = type(str('Meta'), (), meta)
     return type(str(name), (models.Model,), dict(Meta=Meta, __module__=__name__, **fields))
 
 
 def create_deferred_base_class(name, fields={}, meta={}):
     meta.setdefault('app_label', 'foo')
     meta.setdefault('abstract', True)
-    Meta = type(b'Meta', (), meta)
+    Meta = type(str('Meta'), (), meta)
     return type(
         str(name),
         (six.with_metaclass(deferred.ForeignKeyBuilder, models.Model),),
@@ -29,7 +29,7 @@ def create_deferred_base_class(name, fields={}, meta={}):
 
 def create_deferred_class(name, base, fields={}, meta={}, mixins=()):
     meta.setdefault('app_label', 'bar')
-    Meta = type(b'Meta', (), meta)
+    Meta = type(str('Meta'), (), meta)
     return type(str(name), mixins + (base,), dict(Meta=Meta, __module__=__name__, **fields))
 
 
@@ -255,7 +255,7 @@ class DeferredTestCase(TestCase):
         create_deferred_class('OrderPaymentSubclass2', OrderPayment)
 
     def test_mixins_allowed(self):
-        SomeMixin = type(b'SomeMixin', (object,), {})
+        SomeMixin = type(str('SomeMixin'), (object,), {})
         BaseModel = create_regular_class('BaseModel', meta={'abstract': True})
         MixinBaseProduct = create_deferred_base_class('MixinBaseProduct')
         MixinProduct = create_deferred_class('MixinProduct', MixinBaseProduct, mixins=(SomeMixin, BaseModel))

--- a/shop/apps.py
+++ b/shop/apps.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 from django import get_version
 from django.apps import AppConfig
 from django.utils.translation import ugettext_lazy as _
-from shop.deferred import ForeignKeyBuilder
 
 
 class ShopConfig(AppConfig):
@@ -15,6 +14,7 @@ class ShopConfig(AppConfig):
         from django_fsm.signals import post_transition
         from shop.models.fields import JSONField
         from rest_framework.serializers import ModelSerializer
+        from shop.deferred import ForeignKeyBuilder
         from shop.rest.fields import JSONSerializerField
         from shop.models.notification import order_event_notification
 

--- a/shop/deferred.py
+++ b/shop/deferred.py
@@ -103,7 +103,10 @@ class ForeignKeyBuilder(ModelBase):
                 continue
             if not isinstance(member, DeferredRelatedField):
                 continue
-            mapmodel = cls._materialized_models.get(member.abstract_model)
+            if member.abstract_model == 'self':
+                mapmodel = Model
+            else:
+                mapmodel = cls._materialized_models.get(member.abstract_model)
             if mapmodel:
                 field = member.MaterializedField(mapmodel, **member.options)
                 field.contribute_to_class(Model, attrname)

--- a/shop/deferred.py
+++ b/shop/deferred.py
@@ -225,8 +225,14 @@ class MaterializedModel(LazyObject):
             # not self.__class__, because the latter is proxied.
             return type(self)(self._base_model)
         else:
-            # If initialized, return a copy of the wrapped object.
-            return copy.copy(self._wrapped)
+            # In Python 2.7 we can't return `copy.copy(self._wrapped)`,
+            # it fails with `TypeError: can't pickle int objects`.
+            # In Python 3 it works, because it checks if the copied value
+            # is a subclass of `type`.
+            # In this case it just returns the value.
+            # As we know that self._wrapped is a subclass of `type`,
+            # we can just return it here.
+            return self._wrapped
 
     def __deepcopy__(self, memo):
         if self._wrapped is empty:

--- a/shop/deferred.py
+++ b/shop/deferred.py
@@ -101,7 +101,7 @@ class ForeignKeyBuilder(ModelBase):
             else:
                 if basename in cls._materialized_models:
                     if Model.__name__ != cls._materialized_models[basename]:
-                        raise AssertionError("Both Model classes '%s' and '%s' inherited from abstract"
+                        raise ImproperlyConfigured("Both Model classes '%s' and '%s' inherited from abstract"
                             "base class %s, which is disallowed in this configuration." %
                             (Model.__name__, cls._materialized_models[basename], basename))
                 elif isinstance(baseclass, cls):

--- a/shop/deferred.py
+++ b/shop/deferred.py
@@ -114,7 +114,7 @@ class ForeignKeyBuilder(ModelBase):
             cls.process_pending_mappings(Model, basename)
 
         cls.handle_deferred_foreign_fields(Model)
-        Model.perform_model_checks()
+        cls.perform_model_checks(Model)
         return Model
 
     @classmethod
@@ -182,7 +182,7 @@ class ForeignKeyBuilder(ModelBase):
         return object.__getattribute__(self, key)
 
     @classmethod
-    def perform_model_checks(cls):
+    def perform_model_checks(cls, Model):
         """
         Hook for each class inheriting from ForeignKeyBuilder, to perform checks on the
         implementation of the just created class type.
@@ -234,3 +234,13 @@ class MaterializedModel(SimpleLazyObject):
         if self._wrapped is empty:
             self._setup()
         return isinstance(instance, self._materialized_model)
+
+
+try:
+    from polymorphic.models import PolymorphicModelBase
+
+    class PolymorphicForeignKeyBuilder(ForeignKeyBuilder, PolymorphicModelBase):
+        pass
+
+except ImportError:
+    pass

--- a/shop/deferred.py
+++ b/shop/deferred.py
@@ -5,6 +5,8 @@ from django.db.models.base import ModelBase
 from django.db import models
 from django.utils import six
 from django.utils.functional import SimpleLazyObject, empty
+from polymorphic.models import PolymorphicModelBase
+
 from shop import app_settings
 
 
@@ -236,11 +238,5 @@ class MaterializedModel(SimpleLazyObject):
         return isinstance(instance, self._materialized_model)
 
 
-try:
-    from polymorphic.models import PolymorphicModelBase
-
-    class PolymorphicForeignKeyBuilder(ForeignKeyBuilder, PolymorphicModelBase):
-        pass
-
-except ImportError:
+class PolymorphicForeignKeyBuilder(ForeignKeyBuilder, PolymorphicModelBase):
     pass

--- a/shop/deferred.py
+++ b/shop/deferred.py
@@ -90,8 +90,7 @@ class ForeignKeyBuilder(ModelBase):
                 if not isinstance(baseclass, cls):
                     continue
 
-                if not issubclass(baseclass, models.Model):
-                    continue
+                assert issubclass(baseclass, models.Model)
 
                 basename = baseclass.__name__
 
@@ -198,6 +197,10 @@ class ForeignKeyBuilder(ModelBase):
             raise ImproperlyConfigured(msg.format(pm[0][0].__name__, pm[0][1]))
 
 
+class PolymorphicForeignKeyBuilder(ForeignKeyBuilder, PolymorphicModelBase):
+    pass
+
+
 class MaterializedModel(SimpleLazyObject):
     """
     Wrap the base model into a lazy object, so that we can refer to members of its
@@ -236,7 +239,3 @@ class MaterializedModel(SimpleLazyObject):
         if self._wrapped is empty:
             self._setup()
         return isinstance(instance, self._materialized_model)
-
-
-class PolymorphicForeignKeyBuilder(ForeignKeyBuilder, PolymorphicModelBase):
-    pass

--- a/shop/models/product.py
+++ b/shop/models/product.py
@@ -56,19 +56,18 @@ class PolymorphicProductMetaclass(PolymorphicModelBase):
             # refer to it via its materialized Product model.
             if not isinstance(baseclass, cls):
                 continue
+
+            basename = baseclass.__name__
+
             try:
-                if issubclass(baseclass._materialized_model, Model):
-                    # as the materialized model, use the most generic one
-                    baseclass._materialized_model = Model
-                elif not issubclass(Model, baseclass._materialized_model):
+                if not issubclass(Model, baseclass._materialized_model):
                     raise ImproperlyConfigured("Abstract base class {} has already been associated "
                         "with a model {}, which is different or not a submodel of {}."
                         .format(name, Model, baseclass._materialized_model))
             except (AttributeError, TypeError):
                 baseclass._materialized_model = Model
-
-            # check for pending mappings in the ForeignKeyBuilder and in case, process them
-            deferred.ForeignKeyBuilder.process_pending_mappings(Model, baseclass.__name__)
+                deferred.ForeignKeyBuilder._materialized_models[basename] = Model.__name__
+                deferred.ForeignKeyBuilder.process_pending_mappings(Model, basename)
 
         deferred.ForeignKeyBuilder.handle_deferred_foreign_fields(Model)
         cls.perform_model_checks(Model)


### PR DESCRIPTION
While adding tests for the deferred module I realized that foreign keys to `self` and `ManyToManyField` with a `through` model are not handled.
Those are fixed in this PR as well.
What I still would like to do is to refactor the `PolymorphicProductMetaclass` by supporting polymorphic models in the deferred module as well. Many things are duplicated otherwise.
I think that it is not too much effort, as we could weaken the restriction, that materialized models can't be extended itself: https://github.com/awesto/django-shop/commit/e24b17569dd9574e98d6bf387da756fee7c6b33f#diff-afc3e76997a83a3092d8667733a44159R194
This, plus some kind of choosing the `PolymorphicModelBase` instead of `ModelBase` should make this possible.
What are your opinions for this @jrief @rfleschenberg ?
