### PR TITLE
Added enum34 for backwards compatibility

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -50,3 +50,4 @@ virtualenv==13.1.2
 wheel==0.24.0
 bs4==0.0.1
 python-dateutil==2.5.3
+enum34==1.1.6


### PR DESCRIPTION
I couldn't get the example to start with python 2.7 without it. 
