### PR TITLE
Do not use X-HTTP-Method-Override header in postCartItem

### DIFF
--- a/shop/static/shop/js/cart.js
+++ b/shop/static/shop/js/cart.js
@@ -16,11 +16,14 @@ djangoShopModule.controller('CartController', ['$scope', '$http', function($scop
 	}
 
 	function postCartItem(cart_item, method) {
-		var config = {headers: {'X-HTTP-Method-Override': method}};
 		if (isLoading)
 			return;
 		isLoading = true;
-		$http.post(cart_item.url, cart_item, config).then(function(response) {
+		$http({
+			method: method,
+			url: cart_item.url,
+			data: cart_item,
+		}).then(function(response) {
 			return $http.get($scope.$parent.cartListURL);
 		}).then(function(response) {
 			isLoading = false;


### PR DESCRIPTION
Prior to this change, if you were running djangorestframework>=3.3.0, cart.js would break if you tried to update the quantity of an item or remove an item from your cart, due to the use of the `X-HTTP-Method-Override` header. This change allows you to use djangorestframework>=3.3.0 (I'm running 3.5.3) in conjunction with django-shop.

http://www.django-rest-framework.org/topics/browser-enhancements/#http-header-based-method-overriding