### PR TITLE
Tutorial: tell the user which docs to read

### DIFF
--- a/docs/tutorial/intro.rst
+++ b/docs/tutorial/intro.rst
@@ -52,6 +52,7 @@ system:
 	$ mkdir Tutorial; cd Tutorial
 	$ virtualenv -p $(which python3) shoptutorial
 	$ source shoptutorial/bin/activate
+	(shoptutorial)$ pip install -U pip setuptools
 	(shoptutorial)$ git clone --depth 1 https://github.com/awesto/django-shop
 	(shoptutorial)$ cd django-shop
 	(shoptutorial)$ pip install -r requirements/common.txt

--- a/docs/tutorial/intro.rst
+++ b/docs/tutorial/intro.rst
@@ -33,6 +33,11 @@ the pip-installable from PyPI only contains the framework, but not the files req
 Before proceeding, please make sure virtualenv_ is installed on your system, otherwise you would
 pollute your Python site-packages folder.
 
+Because we are using the current Github master for this tutorial, you must also
+use the documentation for the current Github master. If you are reading this
+document on Read The Docs, please look for the version selector (usually at the
+bottom of the screen) and select "latest".
+
 Also ensure that these packages are installed using the favorite package manager of your operating
 system:
 

--- a/docs/tutorial/intro.rst
+++ b/docs/tutorial/intro.rst
@@ -50,7 +50,7 @@ system:
 .. code-block:: shell
 
 	$ mkdir Tutorial; cd Tutorial
-	$ virtualenv shoptutorial
+	$ virtualenv -p $(which python3) shoptutorial
 	$ source shoptutorial/bin/activate
 	(shoptutorial)$ git clone --depth 1 https://github.com/awesto/django-shop
 	(shoptutorial)$ cd django-shop


### PR DESCRIPTION
Refs #536 

On Read The Docs, we tell the user to use the master branch. But they are most likely reading the docs for the latest release, which contain outdated instructions.