### PR TITLE
remove never used fields from OrderListSerializer

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,8 @@ Changelog for django-SHOP
 
 * Fixed: :meth:`shop.models.order.OrderManager.get_summary_url` only worked for views rendered
   as CMS page. Now it also works for static Django views.
+* In :class:`shop.serializers.order.OrderListSerializer` removed fields which never are used and
+  reverted the inclusion logic to include fields explicitly instead of excluding.
 
 
 0.10.2

--- a/shop/serializers/order.py
+++ b/shop/serializers/order.py
@@ -12,27 +12,59 @@ from shop.rest.money import MoneyField
 
 
 class OrderListSerializer(serializers.ModelSerializer):
-    number = serializers.CharField(source='get_number', read_only=True)
-    customer = app_settings.CUSTOMER_SERIALIZER(read_only=True)
-    url = serializers.URLField(source='get_absolute_url', read_only=True)
-    status = serializers.CharField(source='status_name', read_only=True)
+    number = serializers.CharField(
+        source='get_number',
+        read_only=True,
+    )
+
+    url = serializers.URLField(
+        source='get_absolute_url',
+        read_only=True,
+    )
+
+    status = serializers.CharField(
+        source='status_name',
+        read_only=True,
+    )
+
     subtotal = MoneyField()
     total = MoneyField()
-    extra = serializers.DictField(read_only=True)
 
     class Meta:
         model = OrderModel
-        exclude = ('id', 'stored_request', '_subtotal', '_total',)
+        fields = ['number', 'url', 'created_at', 'updated_at', 'subtotal', 'total', 'status',
+                  'shipping_address_text', 'billing_address_text']
 
 
 class OrderDetailSerializer(OrderListSerializer):
-    items = app_settings.ORDER_ITEM_SERIALIZER(many=True, read_only=True)
+    items = app_settings.ORDER_ITEM_SERIALIZER(
+        many=True,
+        read_only=True,
+    )
+
+    extra = serializers.DictField(read_only=True)
     amount_paid = MoneyField(read_only=True)
     outstanding_amount = MoneyField(read_only=True)
-    is_partially_paid = serializers.SerializerMethodField(method_name='get_partially_paid',
-        help_text="Returns true, if order has been partially paid")
-    annotation = serializers.CharField(write_only=True, required=False)
-    reorder = serializers.BooleanField(write_only=True, default=False)
+    customer = app_settings.CUSTOMER_SERIALIZER(read_only=True)
+
+    is_partially_paid = serializers.SerializerMethodField(
+        method_name='get_partially_paid',
+        help_text="Returns true, if order has been partially paid",
+    )
+
+    annotation = serializers.CharField(
+        write_only=True,
+        required=False,
+    )
+
+    reorder = serializers.BooleanField(
+        write_only=True,
+        default=False,
+    )
+
+    class Meta:
+        model = OrderModel
+        exclude = ['id', 'stored_request', '_subtotal', '_total']
 
     def get_partially_paid(self, order):
         return order.amount_paid > 0


### PR DESCRIPTION
After having a look at the serialized fields of the Order's list serializer, I removed those which actually never are used.