### PR TITLE
Dynamic payment modifier valid option updates

### DIFF
--- a/shop/forms/checkout.py
+++ b/shop/forms/checkout.py
@@ -294,7 +294,7 @@ class ValueInsertRenderer(RadioFieldRenderer):
 
 class PaymentMethodForm(DialogForm):
     # from 2nd element of prefix used, always in response after 'data'
-    # is put assigned using `$rootScope.data = response.data;`
+    # is assigned using `$rootScope.data = response.data;`
     scope_prefix = 'data.payment_method'
 
     payment_modifier = fields.ChoiceField(label=_("Payment Method"),

--- a/shop/forms/checkout.py
+++ b/shop/forms/checkout.py
@@ -330,6 +330,7 @@ class PaymentMethodForm(DialogForm):
         """
         Override default that returns nothing.
         Add 'choices' payment modifier list for dynamic client-side disable
+        Must match the __init__ choices, otherwise validation will differ between server & client
         """
         choices = [choice[0] for choice in self.base_fields['payment_modifier'].choices]
         return {'choices': choices}

--- a/shop/modifiers/base.py
+++ b/shop/modifiers/base.py
@@ -135,11 +135,15 @@ class PaymentModifier(BaseCartModifier):
         """
         raise NotImplemented("Must be implemented by the inheriting class")
 
-    def is_active(self, cart):
+    def is_active(self, cart, request=None):
         """
         Returns true if this payment modifier is active.
+        Deprecation: calls should always supply a request so that '=None' can be removed
         """
-        return cart.extra.get('payment_modifier') == self.identifier
+        try:
+            return request.data['payment_method']['payment_modifier'] == self.identifier
+        except (AttributeError, KeyError):
+            return cart.extra.get('payment_modifier') == self.identifier
 
     def is_disabled(self, cart):
         """
@@ -167,11 +171,15 @@ class ShippingModifier(BaseCartModifier):
         """
         raise NotImplemented("Must be implemented by the inheriting class")
 
-    def is_active(self, cart):
+    def is_active(self, cart, request=None):
         """
         Returns true if this shipping modifier is active.
+        Deprecation: calls should always supply a request so that '=None' can be removed
         """
-        return cart.extra.get('shipping_modifier') == self.identifier
+        try:
+            return request.data['shipping_method']['shipping_modifier'] == self.identifier
+        except (AttributeError, KeyError):
+            return cart.extra.get('shipping_modifier') == self.identifier
 
     def is_disabled(self, cart):
         """

--- a/shop/static/shop/js/dialogs.js
+++ b/shop/static/shop/js/dialogs.js
@@ -40,6 +40,7 @@ djangoShopModule.controller('DialogController',
 			}
 			$rootScope.cart = response.cart;
 			$rootScope.checkout_summary = response.checkout_summary;
+			$rootScope.data = response.data;
 		}).error(function(errors) {
 			console.error("Unable to upload checkout forms:");
 			console.log(errors);

--- a/shop/views/checkout.py
+++ b/shop/views/checkout.py
@@ -67,7 +67,9 @@ class CheckoutViewSet(BaseViewSet):
         # save data, get text representation and collect potential errors
         errors, checkout_summary, response_data = {}, {}, {'$valid': True}
         with transaction.atomic():
+            # only validates the relevant submitted checkout page form data
             for form_class, data in dialog_data:
+                # payment & shipping method forms call cart.update(request) which runs all modifiers
                 form = form_class.form_factory(request, data, cart)
                 if form.is_valid():
                     # empty error dict forces revalidation by the client side validation
@@ -85,8 +87,9 @@ class CheckoutViewSet(BaseViewSet):
                     response_data[key] = update_data
             cart.save()
 
-        # add possible form errors for giving feedback to the customer
+        # produces a response with correct cart contents by running all modifiers via cart.update(request)
         response = self.list(request)
+        # adds the rest of the data for the checkout forms including customer feedback errors
         response.data.update(errors=errors, checkout_summary=checkout_summary, data=response_data)
         return response
 


### PR DESCRIPTION
Payment modifier `is_disabled()` changes will be reflected in radio options being disabled dynamically.
This has specifically been developed to allow changes in shipping modifier to dynamically affect the available payment modifiers and is a solution to issue #592 -

**Shipping modifier:**
```
    def add_extra_cart_row(self, cart, request):
        cart.total_incomplete = False
        # if not added and others available
        if not self.is_active(cart, request) and len(cart_modifiers_pool.get_shipping_modifiers()) > 1:
            return
        ...
        cart.total_incomplete = True
```
**Payment modifier:**
```
def is_disabled(self, cart):
        "if shipping cost is unknown, disable"
        disable = (cart.total == 0) or getattr(cart, 'total_incomplete')
        return disable
```
