### PR TITLE
Check for older Postgresql engine name for JSONField

### DIFF
--- a/shop/models/fields.py
+++ b/shop/models/fields.py
@@ -3,8 +3,12 @@ from __future__ import unicode_literals
 
 from django.conf import settings
 
+postgresql_engine_names = [
+    'django.db.backends.postgresql',
+    'django.db.backends.postgresql_psycopg2',
+]
 
-if settings.DATABASES['default']['ENGINE'] == 'django.db.backends.postgresql':
+if settings.DATABASES['default']['ENGINE'] in postgresql_engine_names:
     from django.contrib.postgres.fields import JSONField as _JSONField
 else:
     from jsonfield.fields import JSONField as _JSONField


### PR DESCRIPTION
The Postgresql database engine name was changed from
'django.db.backends.postgresql_psycopg2' to
'django.db.backends.postgresql' in Django 1.9. However, the former name
still works in newer versions of Django for compatibility reasons. This
value should also be checked when deciding which JSONField to use, since
it is common in older projects that have upgraded from previous versions
of Django.

See the link below for more information:
https://docs.djangoproject.com/en/1.9/ref/settings/#engine