### PR TITLE
Cancel order with refund

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,10 +8,20 @@ Changelog for django-SHOP
 ======
 
 * Do not render buttons and links related to the watch-list, when it is not available.
-* Use Sekizai's internal ``{% with_data ... %}`` to render Sekizai blocks ``ng-requires`` and
-  ``ng-config`` rather than using the deprecated postprocessors ``djng.sekizai_processors.module_list``
-  and ``djng.sekizai_processors.module_config``. Adopt your templates accordingly as explained
-  in :ref:`reference/client-framework`
+* Use Sekizai's internal templatetags ``{% with_data ... %}`` and ``{% with_data %}`` to render Sekizai
+  blocks ``ng-requires`` and ``ng-config`` rather than using the deprecated postprocessors
+  ``djng.sekizai_processors.module_list`` and ``djng.sekizai_processors.module_config``. Adopt your
+  templates accordingly as explained in :ref:`reference/client-framework`.
+* Rename ``PayInAdvanceWorkflowMixin`` to ``ManualPaymentWorkflowMixin``, since its purpose is to
+  handle all incoming/outgoing payments manually.
+* Move ``LeftExtensionPlugin`` and ``RightExtensionPlugin`` into module ``shop/cascade/extensions``
+  and allow them to be used on the ``ShopOrderViewsPlugin`` as well.
+* ``ShopOrderAddendumFormPlugin`` can optionally render historical annotations for the given order.
+* Added hook methods ``cancelable()`` and ``refund_payment()`` to ``BaseOrder`` to allow
+  a better order cancelling interface.
+* Paid but unshipped orders, now can be refunded. Possible be refactoring class
+  ``CancelOrderWorkflowMixin``, which handles payment refunds.
+* Add Order status to Order Detail View, so that the customer immediately sees what's going on.
 
 
 0.11.1

--- a/example/myshop/migrations/commodity/0001_initial.py
+++ b/example/myshop/migrations/commodity/0001_initial.py
@@ -123,7 +123,7 @@ class Migration(migrations.Migration):
                 'verbose_name': 'Order',
                 'verbose_name_plural': 'Orders',
             },
-            bases=(shop.payment.defaults.PayInAdvanceWorkflowMixin, shop.payment.defaults.CancelOrderWorkflowMixin, shop_stripe.payment.OrderWorkflowMixin, shop.shipping.defaults.CommissionGoodsWorkflowMixin, models.Model),
+            bases=(shop.payment.defaults.ManualPaymentWorkflowMixin, shop.payment.defaults.CancelOrderWorkflowMixin, shop_stripe.payment.OrderWorkflowMixin, shop.shipping.defaults.CommissionGoodsWorkflowMixin, models.Model),
         ),
         migrations.CreateModel(
             name='OrderItem',

--- a/example/myshop/migrations/i18n_commodity/0001_initial.py
+++ b/example/myshop/migrations/i18n_commodity/0001_initial.py
@@ -132,7 +132,7 @@ class Migration(migrations.Migration):
                 'verbose_name': 'Order',
                 'verbose_name_plural': 'Orders',
             },
-            bases=(shop.payment.defaults.PayInAdvanceWorkflowMixin, shop.payment.defaults.CancelOrderWorkflowMixin, shop_stripe.payment.OrderWorkflowMixin, shop.shipping.defaults.CommissionGoodsWorkflowMixin, models.Model),
+            bases=(shop.payment.defaults.ManualPaymentWorkflowMixin, shop.payment.defaults.CancelOrderWorkflowMixin, shop_stripe.payment.OrderWorkflowMixin, shop.shipping.defaults.CommissionGoodsWorkflowMixin, models.Model),
         ),
         migrations.CreateModel(
             name='OrderItem',

--- a/example/myshop/migrations/i18n_polymorphic/0001_initial.py
+++ b/example/myshop/migrations/i18n_polymorphic/0001_initial.py
@@ -135,7 +135,7 @@ class Migration(migrations.Migration):
                 'verbose_name': 'Order',
                 'verbose_name_plural': 'Orders',
             },
-            bases=(shop.payment.defaults.PayInAdvanceWorkflowMixin, shop.payment.defaults.CancelOrderWorkflowMixin, shop_stripe.payment.OrderWorkflowMixin, shop.shipping.delivery.PartialDeliveryWorkflowMixin, models.Model),
+            bases=(shop.payment.defaults.ManualPaymentWorkflowMixin, shop.payment.defaults.CancelOrderWorkflowMixin, shop_stripe.payment.OrderWorkflowMixin, shop.shipping.delivery.PartialDeliveryWorkflowMixin, models.Model),
         ),
         migrations.CreateModel(
             name='OrderItem',

--- a/example/myshop/migrations/i18n_smartcard/0001_initial.py
+++ b/example/myshop/migrations/i18n_smartcard/0001_initial.py
@@ -108,7 +108,7 @@ class Migration(migrations.Migration):
                 'verbose_name': 'Order',
                 'verbose_name_plural': 'Orders',
             },
-            bases=(shop.payment.defaults.PayInAdvanceWorkflowMixin, shop.payment.defaults.CancelOrderWorkflowMixin, shop_stripe.payment.OrderWorkflowMixin, shop.shipping.defaults.CommissionGoodsWorkflowMixin, models.Model),
+            bases=(shop.payment.defaults.ManualPaymentWorkflowMixin, shop.payment.defaults.CancelOrderWorkflowMixin, shop_stripe.payment.OrderWorkflowMixin, shop.shipping.defaults.CommissionGoodsWorkflowMixin, models.Model),
         ),
         migrations.CreateModel(
             name='OrderItem',

--- a/example/myshop/migrations/polymorphic/0001_initial.py
+++ b/example/myshop/migrations/polymorphic/0001_initial.py
@@ -134,7 +134,7 @@ class Migration(migrations.Migration):
                 'verbose_name': 'Order',
                 'verbose_name_plural': 'Orders',
             },
-            bases=(shop.payment.defaults.PayInAdvanceWorkflowMixin, shop.payment.defaults.CancelOrderWorkflowMixin, shop_stripe.payment.OrderWorkflowMixin, shop.shipping.delivery.PartialDeliveryWorkflowMixin, models.Model),
+            bases=(shop.payment.defaults.ManualPaymentWorkflowMixin, shop.payment.defaults.CancelOrderWorkflowMixin, shop_stripe.payment.OrderWorkflowMixin, shop.shipping.delivery.PartialDeliveryWorkflowMixin, models.Model),
         ),
         migrations.CreateModel(
             name='OrderItem',

--- a/example/myshop/migrations/smartcard/0001_initial.py
+++ b/example/myshop/migrations/smartcard/0001_initial.py
@@ -107,7 +107,7 @@ class Migration(migrations.Migration):
                 'verbose_name': 'Order',
                 'verbose_name_plural': 'Orders',
             },
-            bases=(shop.payment.defaults.PayInAdvanceWorkflowMixin, shop.payment.defaults.CancelOrderWorkflowMixin, shop_stripe.payment.OrderWorkflowMixin, shop.shipping.defaults.CommissionGoodsWorkflowMixin, models.Model),
+            bases=(shop.payment.defaults.ManualPaymentWorkflowMixin, shop.payment.defaults.CancelOrderWorkflowMixin, shop_stripe.payment.OrderWorkflowMixin, shop.shipping.defaults.CommissionGoodsWorkflowMixin, models.Model),
         ),
         migrations.CreateModel(
             name='OrderItem',

--- a/example/myshop/settings.py
+++ b/example/myshop/settings.py
@@ -580,7 +580,7 @@ if 'shop_stripe' in INSTALLED_APPS:
 SHOP_EDITCART_NG_MODEL_OPTIONS = "{updateOn: 'default blur', debounce: {'default': 2500, 'blur': 0}}"
 
 SHOP_ORDER_WORKFLOWS = [
-    'shop.payment.defaults.PayInAdvanceWorkflowMixin',
+    'shop.payment.defaults.ManualPaymentWorkflowMixin',
     'shop.payment.defaults.CancelOrderWorkflowMixin',
     'shop_stripe.payment.OrderWorkflowMixin',
 ]

--- a/shop/cascade/cart.py
+++ b/shop/cascade/cart.py
@@ -5,31 +5,19 @@ from django.forms import widgets
 from django.template.loader import select_template, get_template
 from django.utils.translation import ugettext_lazy as _
 from django.utils.html import mark_safe
+
 from cms.plugin_pool import plugin_pool
 from cmsplugin_cascade.fields import GlossaryField
-from cmsplugin_cascade.plugin_base import TransparentContainer, TransparentWrapper
+from cmsplugin_cascade.plugin_base import TransparentWrapper
 
 from shop.conf import app_settings
 from shop.models.cart import CartModel
 from shop.serializers.cart import CartSerializer
+from .extensions import ShopExtendableMixin, LeftRightExtensionMixin
 from .plugin_base import ShopPluginBase
 
 
-class ShopExtendableMixin(object):
-    @property
-    def left_extension(self):
-        result = [cp for cp in self.child_plugin_instances if cp.plugin_type == 'ShopLeftExtension']
-        if result:
-            return result[0]
-
-    @property
-    def right_extension(self):
-        result = [cp for cp in self.child_plugin_instances if cp.plugin_type == 'ShopRightExtension']
-        if result:
-            return result[0]
-
-
-class ShopCartPlugin(TransparentWrapper, ShopPluginBase):
+class ShopCartPlugin(LeftRightExtensionMixin, TransparentWrapper, ShopPluginBase):
     name = _("Cart")
     require_parent = True
     parent_classes = ('BootstrapColumnPlugin',)
@@ -94,40 +82,4 @@ class ShopCartPlugin(TransparentWrapper, ShopPluginBase):
             pass
         return self.super(ShopCartPlugin, self).render(context, instance, placeholder)
 
-    @classmethod
-    def get_child_classes(cls, slot, page, instance=None):
-        child_classes = ['ShopLeftExtension', 'ShopRightExtension', None]
-        # allow only one left and one right extension
-        for child in instance.get_children():
-            child_classes.remove(child.plugin_type)
-        return child_classes
-
-    @classmethod
-    def get_child_classes(cls, slot, page, instance=None):
-        child_classes = ['ShopLeftExtension', 'ShopRightExtension', None]
-        # allow only one left and one right extension
-        for child in instance.get_children():
-            child_classes.remove(child.plugin_type)
-        return child_classes
-
 plugin_pool.register_plugin(ShopCartPlugin)
-
-
-class ShopLeftExtension(TransparentContainer, ShopPluginBase):
-    name = _("Left Extension")
-    require_parent = True
-    parent_classes = ('ShopCartPlugin',)
-    allow_children = True
-    render_template = 'cascade/generic/naked.html'
-
-plugin_pool.register_plugin(ShopLeftExtension)
-
-
-class ShopRightExtension(TransparentContainer, ShopPluginBase):
-    name = _("Right Extension")
-    require_parent = True
-    parent_classes = ('ShopCartPlugin',)
-    allow_children = True
-    render_template = 'cascade/generic/naked.html'
-
-plugin_pool.register_plugin(ShopRightExtension)

--- a/shop/cascade/checkout.py
+++ b/shop/cascade/checkout.py
@@ -49,6 +49,7 @@ class ShopProceedButton(BootstrapButtonMixin, ShopButtonPluginBase):
     name = _("Proceed Button")
     parent_classes = ('BootstrapColumnPlugin', 'ProcessStepPlugin', 'ValidateSetOfFormsPlugin')
     model_mixins = (LinkElementMixin,)
+    form = ProceedButtonForm
     glossary_field_order = ('button_type', 'button_size', 'button_options', 'quick_float',
                             'icon_align', 'icon_font', 'symbol')
     ring_plugin = 'ProceedButtonPlugin'
@@ -58,10 +59,6 @@ class ShopProceedButton(BootstrapButtonMixin, ShopButtonPluginBase):
                        'cascade/css/admin/bootstrap-theme.min.css',
                        'cascade/css/admin/iconplugin.css',)}
         js = ['shop/js/admin/proceedbuttonplugin.js']
-
-    def get_form(self, request, obj=None, **kwargs):
-        kwargs.update(form=ProceedButtonForm)
-        return super(ShopProceedButton, self).get_form(request, obj, **kwargs)
 
     def get_render_template(self, context, instance, placeholder):
         template_names = [

--- a/shop/cascade/extensions.py
+++ b/shop/cascade/extensions.py
@@ -27,7 +27,7 @@ class ShopExtendableMixin(object):
 
 class LeftRightExtensionMixin(object):
     """
-    Plugin classes wishing to use extensions, shall inherits from this class.
+    Plugin classes wishing to use extensions shall inherit from this class.
     """
     @classmethod
     def get_child_classes(cls, slot, page, instance=None):

--- a/shop/cascade/extensions.py
+++ b/shop/cascade/extensions.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.utils.translation import ugettext_lazy as _
+from cms.plugin_pool import plugin_pool
+from cmsplugin_cascade.plugin_base import TransparentContainer
+
+from .plugin_base import ShopPluginBase
+
+
+class ShopExtendableMixin(object):
+    """
+    Add this mixin class to the list of ``model_mixins``, in the plugin class wishing to use extensions.
+    """
+    @property
+    def left_extension(self):
+        result = [cp for cp in self.child_plugin_instances if cp.plugin_type == 'ShopLeftExtension']
+        if result:
+            return result[0]
+
+    @property
+    def right_extension(self):
+        result = [cp for cp in self.child_plugin_instances if cp.plugin_type == 'ShopRightExtension']
+        if result:
+            return result[0]
+
+
+class LeftRightExtensionMixin(object):
+    """
+    Plugin classes wishing to use extensions, shall inherits from this class.
+    """
+    @classmethod
+    def get_child_classes(cls, slot, page, instance=None):
+        child_classes = ['ShopLeftExtension', 'ShopRightExtension', None]
+        # allow only one left and one right extension
+        for child in instance.get_children():
+            child_classes.remove(child.plugin_type)
+        return child_classes
+
+
+class ShopLeftExtension(TransparentContainer, ShopPluginBase):
+    name = _("Left Extension")
+    require_parent = True
+    parent_classes = ('ShopCartPlugin', 'ShopOrderViewsPlugin')
+    allow_children = True
+    render_template = 'cascade/generic/naked.html'
+
+    @classmethod
+    def get_child_classes(cls, slot, page, instance=None):
+        child_classes = super(ShopLeftExtension, cls).get_child_classes(slot, page, instance=instance)
+        print("----------------------")
+        print(instance)
+        print(child_classes)
+        print
+        return child_classes
+
+plugin_pool.register_plugin(ShopLeftExtension)
+
+
+class ShopRightExtension(TransparentContainer, ShopPluginBase):
+    name = _("Right Extension")
+    require_parent = True
+    parent_classes = ('ShopCartPlugin', 'ShopOrderViewsPlugin')
+    allow_children = True
+    render_template = 'cascade/generic/naked.html'
+
+plugin_pool.register_plugin(ShopRightExtension)

--- a/shop/cascade/extensions.py
+++ b/shop/cascade/extensions.py
@@ -45,15 +45,6 @@ class ShopLeftExtension(TransparentContainer, ShopPluginBase):
     allow_children = True
     render_template = 'cascade/generic/naked.html'
 
-    @classmethod
-    def get_child_classes(cls, slot, page, instance=None):
-        child_classes = super(ShopLeftExtension, cls).get_child_classes(slot, page, instance=instance)
-        print("----------------------")
-        print(instance)
-        print(child_classes)
-        print
-        return child_classes
-
 plugin_pool.register_plugin(ShopLeftExtension)
 
 

--- a/shop/cascade/order.py
+++ b/shop/cascade/order.py
@@ -7,8 +7,10 @@ from django.core.exceptions import ValidationError
 from django.template import engines
 from django.template.loader import select_template
 from django.utils.translation import ugettext_lazy as _
+
 from cms.plugin_pool import plugin_pool
 from cmsplugin_cascade.bootstrap3.buttons import BootstrapButtonMixin
+from cmsplugin_cascade.fields import GlossaryField
 from cmsplugin_cascade.plugin_base import TransparentWrapper
 
 from djng.forms import fields, NgModelFormMixin
@@ -57,7 +59,7 @@ class ShopOrderViewsPlugin(LeftRightExtensionMixin, TransparentWrapper, ShopPlug
 plugin_pool.register_plugin(ShopOrderViewsPlugin)
 
 
-class ReorderButtonForm(ShopOrderViewsForm):
+class OrderButtonForm(ShopOrderViewsForm):
     button_content = fields.CharField(required=False, label=_("Button Content"),
                                       widget=widgets.TextInput())
 
@@ -66,50 +68,79 @@ class ReorderButtonForm(ShopOrderViewsForm):
         if instance:
             initial = {'button_content': instance.glossary.get('button_content') }
             kwargs.update(initial=initial)
-        super(ReorderButtonForm, self).__init__(raw_data, *args, **kwargs)
+        super(OrderButtonForm, self).__init__(raw_data, *args, **kwargs)
 
     def clean(self):
-        cleaned_data = super(ReorderButtonForm, self).clean()
+        cleaned_data = super(OrderButtonForm, self).clean()
         if self.is_valid():
             cleaned_data['glossary']['button_content'] = cleaned_data['button_content']
         return cleaned_data
 
 
-class ShopReorderFormPlugin(BootstrapButtonMixin, ShopPluginBase):
-    name = _("Reorder Button")
-    parent_classes = ('ShopOrderViewsPlugin',)
-    form = ReorderButtonForm
-    fields = ('button_content', 'glossary',)
-    glossary_field_order = ('button_type', 'button_size', 'button_options', 'quick_float',
-                            'icon_align', 'icon_font', 'symbol')
+class OrderButtonBase(BootstrapButtonMixin, ShopPluginBase):
+    parent_classes = ['ShopOrderViewsPlugin']
+    form = OrderButtonForm
+    fields = ['button_content', 'glossary']
+    glossary_field_order = ['button_type', 'button_size', 'button_options', 'quick_float',
+                            'icon_align', 'icon_font', 'symbol']
 
     class Media:
         css = {'all': ('cascade/css/admin/bootstrap.min.css', 'cascade/css/admin/bootstrap-theme.min.css',)}
+
+    @classmethod
+    def get_identifier(cls, instance):
+        return instance.glossary.get('button_content', '')
+
+    def render(self, context, instance, placeholder):
+        context = super(OrderButtonBase, self).render(context, instance, placeholder)
+        context.update({
+            'button_label': instance.glossary.get('button_content', '')
+        })
+        return context
+
+
+class ShopReorderButtonPlugin(OrderButtonBase):
+    name = _("Reorder Button")
 
     def get_render_template(self, context, instance, placeholder):
         template_names = [
-            '{}/order/reorder-form.html'.format(app_settings.APP_LABEL),
-            'shop/order/reorder-form.html',
+            '{}/order/reorder-button.html'.format(app_settings.APP_LABEL),
+            'shop/order/reorder-button.html',
         ]
         return select_template(template_names)
 
-plugin_pool.register_plugin(ShopReorderFormPlugin)
+plugin_pool.register_plugin(ShopReorderButtonPlugin)
+
+
+class ShopCancelOrderButtonPlugin(OrderButtonBase):
+    name = _("Cancel Order Button")
+
+    def get_render_template(self, context, instance, placeholder):
+        template_names = [
+            '{}/order/cancel-button.html'.format(app_settings.APP_LABEL),
+            'shop/order/cancel-button.html',
+        ]
+        return select_template(template_names)
+
+plugin_pool.register_plugin(ShopCancelOrderButtonPlugin)
 
 
 class AddendumForm(NgModelFormMixin, Bootstrap3Form):
-    scope_prefix = 'data'
-    annotation = fields.CharField(label=_("Supplementary annotation for this Order"), required=False,
-                              widget=widgets.Textarea(attrs={'rows': 4}))
+    annotation = fields.CharField(
+        label=_("Supplementary annotation for this Order"),
+        widget=widgets.Textarea(attrs={'rows': 2}),
+    )
 
 
-class ShopOrderAddendumFormPlugin(BootstrapButtonMixin, ShopPluginBase):
+class ShopOrderAddendumFormPlugin(OrderButtonBase):
     name = _("Order Addendum Form")
-    parent_classes = ('BootstrapColumnPlugin', 'SimpleWrapperPlugin',)
-    form = ReorderButtonForm
-    fields = ('button_content', 'glossary',)
 
-    class Media:
-        css = {'all': ('cascade/css/admin/bootstrap.min.css', 'cascade/css/admin/bootstrap-theme.min.css',)}
+    show_history = GlossaryField(
+         widgets.CheckboxInput(),
+         label=_("Show History"),
+         initial=True,
+         help_text=_("Show historical annotations.")
+    )
 
     def get_render_template(self, context, instance, placeholder):
         template_names = [
@@ -119,8 +150,11 @@ class ShopOrderAddendumFormPlugin(BootstrapButtonMixin, ShopPluginBase):
         return select_template(template_names)
 
     def render(self, context, instance, placeholder):
-        super(ShopOrderAddendumFormPlugin, self).render(context, instance, placeholder)
-        context['addenum_form'] = AddendumForm()
+        context = super(ShopOrderAddendumFormPlugin, self).render(context, instance, placeholder)
+        context.update({
+            'addenum_form': AddendumForm(),
+            'show_history': instance.glossary.get('show_history', True),
+        })
         return context
 
 plugin_pool.register_plugin(ShopOrderAddendumFormPlugin)

--- a/shop/cascade/order.py
+++ b/shop/cascade/order.py
@@ -9,11 +9,13 @@ from django.template.loader import select_template
 from django.utils.translation import ugettext_lazy as _
 from cms.plugin_pool import plugin_pool
 from cmsplugin_cascade.bootstrap3.buttons import BootstrapButtonMixin
+from cmsplugin_cascade.plugin_base import TransparentWrapper
 
 from djng.forms import fields, NgModelFormMixin
 from djng.styling.bootstrap3.forms import Bootstrap3Form
 
 from shop.conf import app_settings
+from .extensions import ShopExtendableMixin, LeftRightExtensionMixin
 from .plugin_base import ShopPluginBase
 
 
@@ -26,10 +28,12 @@ class ShopOrderViewsForm(forms.ModelForm):
         return cleaned_data
 
 
-class ShopOrderViewsPlugin(ShopPluginBase):
+class ShopOrderViewsPlugin(LeftRightExtensionMixin, TransparentWrapper, ShopPluginBase):
     name = _("Order Views")
     require_parent = True
     parent_classes = ('BootstrapColumnPlugin',)
+    allow_children = True
+    model_mixins = (ShopExtendableMixin,)
     form = ShopOrderViewsForm
     cache = False
 
@@ -73,9 +77,11 @@ class ReorderButtonForm(ShopOrderViewsForm):
 
 class ShopReorderFormPlugin(BootstrapButtonMixin, ShopPluginBase):
     name = _("Reorder Button")
-    parent_classes = ('BootstrapColumnPlugin', 'SimpleWrapperPlugin',)
+    parent_classes = ('ShopOrderViewsPlugin',)
     form = ReorderButtonForm
     fields = ('button_content', 'glossary',)
+    glossary_field_order = ('button_type', 'button_size', 'button_options', 'quick_float',
+                            'icon_align', 'icon_font', 'symbol')
 
     class Media:
         css = {'all': ('cascade/css/admin/bootstrap.min.css', 'cascade/css/admin/bootstrap-theme.min.css',)}

--- a/shop/cascade/settings.py
+++ b/shop/cascade/settings.py
@@ -4,4 +4,4 @@ from __future__ import unicode_literals
 from django.conf import settings
 
 CASCADE_PLUGINS = getattr(settings, 'SHOP_CASCADE_PLUGINS',
-    ('auth', 'breadcrumb', 'catalog', 'cart', 'checkout', 'order', 'processbar', 'search',))
+    ('auth', 'breadcrumb', 'catalog', 'cart', 'checkout', 'extensions', 'order', 'processbar', 'search',))

--- a/shop/cascade/settings.py
+++ b/shop/cascade/settings.py
@@ -2,6 +2,24 @@
 from __future__ import unicode_literals
 
 from django.conf import settings
+from cmsplugin_cascade.extra_fields.config import PluginExtraFieldsConfig
+
 
 CASCADE_PLUGINS = getattr(settings, 'SHOP_CASCADE_PLUGINS',
     ('auth', 'breadcrumb', 'catalog', 'cart', 'checkout', 'extensions', 'order', 'processbar', 'search',))
+
+
+def set_defaults(config):
+    config.setdefault('plugins_with_extra_fields', {})
+    config['plugins_with_extra_fields'].setdefault('ShopReorderButtonPlugin', PluginExtraFieldsConfig(
+        inline_styles={
+            'extra_fields:Margins': ['margin-top', 'margin-right', 'margin-bottom', 'margin-left'],
+            'extra_units:Margins': 'px,em'
+        },
+    ))
+    config['plugins_with_extra_fields'].setdefault('ShopCancelOrderButtonPlugin', PluginExtraFieldsConfig(
+        inline_styles={
+            'extra_fields:Margins': ['margin-top', 'margin-right', 'margin-bottom', 'margin-left'],
+            'extra_units:Margins': 'px,em'
+        },
+    ))

--- a/shop/models/order.py
+++ b/shop/models/order.py
@@ -363,6 +363,15 @@ class BaseOrder(with_metaclass(WorkflowMixinMetaclass, models.Model)):
         by all external plugins to check, if an Order object has been fully paid.
         """
 
+    def cancelable(self):
+        """
+        Returns True if the current Order is cancelable.
+
+        This method is just a hook and must be overridden by a mixin class
+        managing Order cancellations.
+        """
+        return False
+
     def refund_payment(self):
         """
         Hook to handle payment refunds.

--- a/shop/models/order.py
+++ b/shop/models/order.py
@@ -320,6 +320,7 @@ class BaseOrder(with_metaclass(WorkflowMixinMetaclass, models.Model)):
                 cart_item.quantity = max(cart_item.quantity, order_item.quantity)
             else:
                 cart_item = CartItemModel(cart=cart, product=order_item.product,
+                                          product_code=order_item.product_code,
                                           quantity=order_item.quantity, extra=extra)
             cart_item.save()
 

--- a/shop/models/order.py
+++ b/shop/models/order.py
@@ -328,6 +328,11 @@ class BaseOrder(with_metaclass(WorkflowMixinMetaclass, models.Model)):
         by all external plugins to check, if an Order object has been fully paid.
         """
 
+    def refund_payment(self):
+        """
+        Hook to handle payment refunds.
+        """
+
     @classmethod
     def get_all_transitions(cls):
         """
@@ -349,6 +354,7 @@ class BaseOrder(with_metaclass(WorkflowMixinMetaclass, models.Model)):
 OrderModel = deferred.MaterializedModel(BaseOrder)
 
 
+@python_2_unicode_compatible
 class OrderPayment(with_metaclass(deferred.ForeignKeyBuilder, models.Model)):
     """
     A model to hold received payments for a given order.
@@ -365,6 +371,9 @@ class OrderPayment(with_metaclass(deferred.ForeignKeyBuilder, models.Model)):
     class Meta:
         verbose_name = pgettext_lazy('order_models', "Order payment")
         verbose_name_plural = pgettext_lazy('order_models', "Order payments")
+
+    def __str__(self):
+        return _("Payment ID: {}").format(self.id)
 
 
 @python_2_unicode_compatible

--- a/shop/modifiers/defaults.py
+++ b/shop/modifiers/defaults.py
@@ -31,7 +31,7 @@ class DefaultCartModifier(BaseCartModifier):
 
 class PayInAdvanceModifier(PaymentModifier):
     """
-    This modifiers has not influence on the cart final. It can be used,
+    This modifiers has no influence on the cart final. It can be used,
     to enable the customer to pay the products on delivery.
     """
     identifier = 'pay-in-advance'

--- a/shop/payment/defaults.py
+++ b/shop/payment/defaults.py
@@ -1,9 +1,12 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+from django.core.exceptions import ImproperlyConfigured
 from django.utils.translation import ugettext_lazy as _
-from django_fsm import transition
-from shop.models.order import OrderModel
+
+from django_fsm import transition, RETURN_VALUE
+
+from shop.models.order import BaseOrder, OrderModel
 from .base import PaymentProvider
 
 
@@ -86,26 +89,35 @@ class ManualPaymentWorkflowMixin(object):
         """
         self.acknowledge_payment()
 
+    @transition(field='status', source='refund_payment', target=RETURN_VALUE('refund_payment', 'order_canceled'),
+                custom=dict(admin=True, button_name=_("Mark as Refunded")))
+    def payment_refunded(self):
+        """
+        Signals that the payment for this Order has been refunded manually.
+        """
+        return 'refund_payment' if self.amount_paid else 'order_canceled'
+
 
 class CancelOrderWorkflowMixin(object):
     """
     Add this class to `settings.SHOP_ORDER_WORKFLOWS` to mix it into your `OrderModel`.
-    It adds all the methods required for state transitions, to cancel an unpaid order.
+    It adds all the methods required for state transitions, to cancel an order.
     """
+    CANCELABLE_SOURCES = {'new', 'created', 'payment_confirmed', 'payment_declined'}
     TRANSITION_TARGETS = {
+        'refund_payment': _("Refund payment"),
         'order_canceled': _("Order Canceled"),
     }
-    UNCANCELABLE_TARGETS = ['order_canceled']
-
-    def no_open_deposits(self):
-        return self.amount_paid == 0
 
     def cancelable(self):
-        return self.status not in self.UNCANCELABLE_TARGETS
+        return self.status in self.CANCELABLE_SOURCES
 
-    @transition(field='status', source=['*'], target='order_canceled',
-        conditions=[no_open_deposits, cancelable], custom=dict(admin=True, button_name=_("Cancel Order")))
+    @transition(field='status', target=RETURN_VALUE(*TRANSITION_TARGETS.keys()),
+                conditions=[cancelable], custom=dict(admin=True, button_name=_("Cancel Order")))
     def cancel_order(self):
         """
         Signals that an Order shall be canceled.
         """
+        if self.amount_paid:
+            self.refund_payment()
+        return 'refund_payment' if self.amount_paid else 'order_canceled'

--- a/shop/static/shop/css/order.scss
+++ b/shop/static/shop/css/order.scss
@@ -1,5 +1,5 @@
 table {
 	.shop-order-price-col {
-		width: 140px;
+		width: 20%;
 	}
 }

--- a/shop/static/shop/js/utils.js
+++ b/shop/static/shop/js/utils.js
@@ -49,7 +49,7 @@ djangoShopModule.provider('djangoShop', function() {
 });
 
 
-// Use to filter to create a list of intergers for iteration by ``ng-repeat`` and similar.
+// Used as filter to create a list of integers for iteration by ``ng-repeat`` and similar.
 // Usage: ``<div ng-repeat="x in some_value|range:1" ng-bind="x"></div>``
 // If ``some_value`` is 3, then the above is rendered as ``<div>1</div><div>2</div><div>3</div>``.
 djangoShopModule.filter('range', function() {

--- a/shop/templates/shop/cart/editable.html
+++ b/shop/templates/shop/cart/editable.html
@@ -1,4 +1,7 @@
-{% load i18n static cascade_tags cms_tags sekizai_tags %}
+{% load i18n static cascade_tags sekizai_tags %}
+{% load page_url from cms_tags %}
+{% load render_plugin from cascade_tags %}
+
 
 {% addtoblock "js" %}<script src="{% static 'djng/js/django-angular.min.js' %}" type="text/javascript"></script>{% endaddtoblock %}
 {% addtoblock "ng-requires" %}djng.forms{% endaddtoblock %}

--- a/shop/templates/shop/order/cancel-button.html
+++ b/shop/templates/shop/order/cancel-button.html
@@ -9,22 +9,16 @@
 	<p class="bg-warning">{% blocktrans %}
 		Please embed this plugin into a <code>SegmentationPlugin</code> with condition <code>if not many</code>.
 	{% endblocktrans %}</p>
-{% else %}
-	{% if show_history and data.extra.addenum %}
-		<label>{% trans "Previous annotations" %}</label>
-		<dl class="dl-horizontal">
-		{% for timestamp, annotation in data.extra.addenum %}
-			<dt shop-timestamp="{{ timestamp }}" time-format="d. MMM yyyy, HH:mm"></dt><dd>{{ annotation }}</dd>
-		{% endfor %}
-		</dl>
-	{% endif %}
+{% elif data.cancelable %}
+	{% page_url "shop-cart" as shop_cart_url %}
 	{% with instance_css_classes=instance.css_classes instance_inline_styles=instance.inline_styles %}
-	<form name="{{ addenum_form.form_name }}" djng-forms-set upload-url="{{ request.path_info }}" novalidate>
-		{{ addenum_form.as_div }}
-		<button ng-click="create().then(reloadPage())" ng-disabled="setIsInvalid"{% if instance_css_classes %} class="{{ instance_css_classes }}"{% endif %}{% if instance_inline_styles %} style="{{ instance_inline_styles }}"{% endif %}>
+	<djng-forms-set upload-url="{{ request.path_info }}">
+		<button ng-click="create({cancel: true}).then(reloadPage())"{% if instance_css_classes %} class="{{ instance_css_classes }}"{% endif %}{% if instance_inline_styles %} style="{{ instance_inline_styles }}"{% endif %}>
 			{{ icon_left }}{{ button_label }}{{ icon_right }}
 		</button>
-	</form>
+	</djng-forms-set>
 	{% endwith %}
+{% else %}
+	<div class="well well-sm text-center">{% trans "This Order can't be cancelled" %}</div>
 {% endif %}
 {% endspaceless %}

--- a/shop/templates/shop/order/detail.html
+++ b/shop/templates/shop/order/detail.html
@@ -1,5 +1,6 @@
 {% extends "shop/order/base.html" %}
 {% load i18n %}
+{% load render_plugin from cascade_tags %}
 
 {% block shop-order-table %}
 
@@ -44,7 +45,9 @@
 	{% block shop-order-tfoot %}
 	<tfoot>
 		<tr>
-			<td colspan="2"></td>
+			<td colspan="2" rowspan="99">
+				{% render_plugin instance.left_extension %}
+			</td>
 			<td><h5>{% trans "Subtotal" %}</h5></td>
 			<td class="text-right">
 				<h5>{{ data.subtotal }}</h5>
@@ -52,23 +55,25 @@
 		</tr>
 		{% for key, extra_row in data.extra.rows %}
 		<tr>
-			<td class="no-border" colspan="2"></td>
 			<td>{{ extra_row.label }}</td>
 			<td class="text-right">{{ extra_row.amount }}</td>
 		</tr>
 		{% endfor %}
 		<tr class="double-border">
-			<td class="no-border" colspan="2"></td>
 			<td><h4>{% trans "Total" %}</h4></td>
 			<td class="text-right">
 				<h4>{{ data.total }}</h4>
 			</td>
 		</tr>
 		<tr>
-			<td class="no-border" colspan="2"></td>
 			<td><h5>{% trans "Thereof Paid" %}</h5></td>
 			<td class="text-right">
 				<h5>{{ data.amount_paid }}</h5>
+			</td>
+		</tr>
+		<tr class="no-border">
+			<td colspan="3" rowspan="0">
+				{% render_plugin instance.right_extension %}
 			</td>
 		</tr>
 	</tfoot>

--- a/shop/templates/shop/order/detail.html
+++ b/shop/templates/shop/order/detail.html
@@ -8,7 +8,7 @@
 	<caption>
 		<h4>{% trans "Order" %} {{ data.number }}
 			<small>{% trans "from" context "order-detail" %} <span shop-timestamp="{{ data.created_at }}"></span></small>
-			<span class="badge pull-right">{% trans "Status" %}: {{ data.status }}</span>
+			<span class="label label-default pull-right">{% trans "Status" %}: {{ data.status }}</span>
 		</h4>
 	</caption>
 	{% endblock %}

--- a/shop/templates/shop/order/list.html
+++ b/shop/templates/shop/order/list.html
@@ -1,5 +1,6 @@
 {% extends "shop/order/base.html" %}
 {% load i18n cms_tags %}
+{% load render_plugin from cascade_tags %}
 
 {% block shop-order-table %}
 
@@ -40,4 +41,8 @@
 	</tfoot>
 		{% endif %}
 	{% endblock shop-order-tfoot %}
+
+	<!-- {# DON'T DELETE THIS LINE #}{% render_plugin instance.left_extension %} -->
+	<!-- {# DON'T DELETE THIS LINE #}{% render_plugin instance.right_extension %} -->
+
 {% endblock shop-order-table %}

--- a/shop/templates/shop/order/reorder-button.html
+++ b/shop/templates/shop/order/reorder-button.html
@@ -10,21 +10,13 @@
 		Please embed this plugin into a <code>SegmentationPlugin</code> with condition <code>if not many</code>.
 	{% endblocktrans %}</p>
 {% else %}
-	{% if show_history and data.extra.addenum %}
-		<label>{% trans "Previous annotations" %}</label>
-		<dl class="dl-horizontal">
-		{% for timestamp, annotation in data.extra.addenum %}
-			<dt shop-timestamp="{{ timestamp }}" time-format="d. MMM yyyy, HH:mm"></dt><dd>{{ annotation }}</dd>
-		{% endfor %}
-		</dl>
-	{% endif %}
+	{% page_url "shop-cart" as shop_cart_url %}
 	{% with instance_css_classes=instance.css_classes instance_inline_styles=instance.inline_styles %}
-	<form name="{{ addenum_form.form_name }}" djng-forms-set upload-url="{{ request.path_info }}" novalidate>
-		{{ addenum_form.as_div }}
-		<button ng-click="create().then(reloadPage())" ng-disabled="setIsInvalid"{% if instance_css_classes %} class="{{ instance_css_classes }}"{% endif %}{% if instance_inline_styles %} style="{{ instance_inline_styles }}"{% endif %}>
+	<djng-forms-set upload-url="{{ request.path_info }}">
+		<button ng-click="create({reorder: true}).then(redirectTo('{{ shop_cart_url }}'))" {% if instance_css_classes %} class="{{ instance_css_classes }}"{% endif %}{% if instance_inline_styles %} style="{{ instance_inline_styles }}"{% endif %}>
 			{{ icon_left }}{{ button_label }}{{ icon_right }}
 		</button>
-	</form>
+	</djng-forms-set>
 	{% endwith %}
 {% endif %}
 {% endspaceless %}

--- a/shop/views/order.py
+++ b/shop/views/order.py
@@ -4,9 +4,8 @@ from __future__ import unicode_literals
 from django.views.decorators.cache import never_cache
 
 from rest_framework import generics, mixins
-from rest_framework.exceptions import NotFound
+from rest_framework.exceptions import NotFound, PermissionDenied, MethodNotAllowed
 from rest_framework.renderers import BrowsableAPIRenderer
-from rest_framework.exceptions import PermissionDenied
 
 from shop.rest.money import JSONRenderer
 from shop.rest.renderers import CMSPageRenderer
@@ -67,7 +66,7 @@ class OrderView(mixins.ListModelMixin, mixins.RetrieveModelMixin, mixins.UpdateM
 
     def post(self, request, *args, **kwargs):
         if self.many:
-            return self.list(request, *args, **kwargs)
+            raise MethodNotAllowed("Method POST is not allowed on Order List View")
         self.update(request, *args, **kwargs)
         return self.retrieve(request, *args, **kwargs)
 


### PR DESCRIPTION
* Rename ``PayInAdvanceWorkflowMixin`` to ``ManualPaymentWorkflowMixin``, since its purpose is to
  handle all incoming/outgoing payments manually.
* Move ``LeftExtensionPlugin`` and ``RightExtensionPlugin`` into module ``shop/cascade/extensions``
  and allow it to be used on the ``ShopOrderViewsPlugin``.
* Refactored ``ShopReorderButtonPligin`` and ``ShopOrderAddendumFormPlugin`` to use the new
  ``djng.forms-set`` directive, as provided by **django-angular** version 1.2.
* ``ShopOrderAddendumFormPlugin`` can optionally render historical annotations for the given order.
* Added hook methods ``cancelable()`` and ``refund_payment()`` to ``BaseOrder`` to allow
  a better order cancelling interface.
* Paid but unshipped orders, now can be refunded. Possible be refactoring class
  ``CancelOrderWorkflowMixin``, which handles payment refunds.
