### PR TITLE
Add django-filter to the list of dependencies in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
         'Django>=1.9.12,<1.11',
         'django-post-office>=3.0.0',
         'django-filer>=1.2.8',
+        'django-filter',
         'django-ipware>=1.1.1',
         'django-fsm>=2.4.0',
         'django-fsm-admin>=1.2.4',


### PR DESCRIPTION
Since shop/filters.py imports from django_filters.