### PR TITLE
Add site name in ModelMultipleChoiceField if site count >=2

### DIFF
--- a/shop/admin/product.py
+++ b/shop/admin/product.py
@@ -7,6 +7,8 @@ from django import forms
 from django.core.cache import cache
 from django.core.exceptions import ImproperlyConfigured
 from django.contrib import admin
+from django.contrib.sites.models import Site
+
 from django.utils.translation import ugettext_lazy as _
 
 from adminsortable2.admin import SortableInlineAdminMixin
@@ -32,6 +34,13 @@ def _find_catalog_list_apphook():
     else:
         raise ImproperlyConfigured("You must register a CMS apphook of type `CatalogListCMSApp`.")
 
+class CategoryModelMultipleChoiceField(forms.ModelMultipleChoiceField):
+    def label_from_instance(self, obj):
+        if Site.objects.count() >=2 :
+            page_sitename=Site.objects.filter(djangocms_nodes=obj.node_id)[0].name
+            return '{} | {}'.format(obj, page_sitename)
+        else:
+            return obj
 
 class CMSPageAsCategoryMixin(object):
     """

--- a/shop/admin/product.py
+++ b/shop/admin/product.py
@@ -77,7 +77,7 @@ class CMSPageAsCategoryMixin(object):
             queryset = Page.objects.filter(**limit_choices_to)
             widget = admin.widgets.FilteredSelectMultiple(_("CMS Pages"), False)
             required = not db_field.blank
-            field = forms.ModelMultipleChoiceField(queryset=queryset, widget=widget, required=required)
+            field = CategoryModelMultipleChoiceField(queryset=queryset, widget=widget, required=required)
             return field
         return super(CMSPageAsCategoryMixin, self).formfield_for_manytomany(db_field, request, **kwargs)
 

--- a/shop/admin/product.py
+++ b/shop/admin/product.py
@@ -8,7 +8,6 @@ from django.core.cache import cache
 from django.core.exceptions import ImproperlyConfigured
 from django.contrib import admin
 from django.contrib.sites.models import Site
-
 from django.utils.translation import ugettext_lazy as _
 
 from adminsortable2.admin import SortableInlineAdminMixin

--- a/shop/admin/product.py
+++ b/shop/admin/product.py
@@ -36,10 +36,10 @@ def _find_catalog_list_apphook():
 class CategoryModelMultipleChoiceField(forms.ModelMultipleChoiceField):
     def label_from_instance(self, obj):
         if Site.objects.count() >=2 :
-            page_sitename=Site.objects.filter(djangocms_nodes=obj.node_id)[0].name
-            return '{} | {}'.format(obj, page_sitename)
+            page_sitename=str(Site.objects.filter(djangocms_nodes=obj.node_id).first().name)
+            return '{} | {}'.format(str(obj), page_sitename)
         else:
-            return obj
+            return str(obj)
 
 class CMSPageAsCategoryMixin(object):
     """


### PR DESCRIPTION
When some pages have the same name across multiple sites (SITE_ID), this PR makes it possible to differentiate them in the admin interface of the categories.