### PR TITLE
Remove reference to django-cms Page depth attribute

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
     zip_safe=False,
     install_requires=[
         'Django>=1.9.12,<2.0',
+        'django-cms>=3.5',
         'django-post-office>=3.0.0',
         'django-filer>=1.2.8',
         'django-ipware>=1.1.1',

--- a/shop/models/product.py
+++ b/shop/models/product.py
@@ -198,7 +198,7 @@ class CMSPageReferenceMixin(object):
         """
         # sorting by highest level, so that the canonical URL
         # associates with the most generic category
-        cms_page = self.cms_pages.order_by('depth').last()
+        cms_page = self.cms_pages.order_by('node__path').last()
         if cms_page is None:
             return urljoin('/category-not-assigned/', self.slug)
         return urljoin(cms_page.get_absolute_url(), self.slug)


### PR DESCRIPTION
The `depth` field of Page was removed in django-cms 3.5.0. See the link below for the migration in which this field was removed. Ordering CMS pages by node__path instead should be a reasonable substitute, but requires `django-cms>=3.5`.

https://github.com/divio/django-cms/blob/3.5.0/cms/migrations/0018_pagenode.py#L157