### PR TITLE
Fix redis compatibility pickle protocol version for py2

### DIFF
--- a/example/myshop/settings.py
+++ b/example/myshop/settings.py
@@ -19,6 +19,8 @@ from django.core.urlresolvers import reverse_lazy
 
 from cmsplugin_cascade.utils import format_lazy
 
+import six
+
 SHOP_APP_LABEL = 'myshop'
 BASE_DIR = os.path.dirname(__file__)
 
@@ -293,11 +295,20 @@ if REDIS_HOST:
         'prefix': 'session-{}'.format(SHOP_TUTORIAL),
         'socket_timeout': 1
     }
+    if six.PY3:
+        # Use the latest protocol version (default)                                                                                                                                                           
+        PICKLE_V=-1
+    else:
+        #py2 compatibility                                                                                                                                                                                    
+        PICKLE_V=2
 
     CACHES = {
         'default': {
             'BACKEND': 'redis_cache.RedisCache',
             'LOCATION': 'redis://{}:6379/1'.format(REDIS_HOST),
+             "OPTIONS": {
+                 "PICKLE_VERSION": PICKLE_V,                                                                                                
+	         }
         },
         'compressor': {
             'BACKEND': 'redis_cache.RedisCache',


### PR DESCRIPTION
#730 
Now this should work for all python versions, instead of only python3.
This may need to clear the cache if there was a protocol error with python 2, with this command:
`$ redis-cli flushall`
