### PR TITLE
Prevents error if DoesNotExist 'shop-cart'

### DIFF
--- a/shop/templates/shop/templatetags/cart-icon.html
+++ b/shop/templates/shop/templatetags/cart-icon.html
@@ -4,8 +4,10 @@
 {% addtoblock "js" %}<script src="{% static 'shop/js/carticon-caption.js' %}" type="text/javascript"></script>{% endaddtoblock %}
 {% add_data "ng-requires" "django.shop.carticon_caption" %}
 
+{% if num_items %}
 {% page_url 'shop-cart' as shop_cart_url %}
 {% page_attribute 'menu_title' 'shop-cart' as tooltip %}
+{% endif %}
 
 <a class="nav-link py-0 pl-lg-3 pr-0"{% if shop_cart_url %} href="{{ shop_cart_url }}" title="{{ tooltip }}"{% endif %}>
 {% block carticon %}

--- a/shop/templates/shop/templatetags/cart-icon.html
+++ b/shop/templates/shop/templatetags/cart-icon.html
@@ -4,7 +4,7 @@
 {% addtoblock "js" %}<script src="{% static 'shop/js/carticon-caption.js' %}" type="text/javascript"></script>{% endaddtoblock %}
 {% add_data "ng-requires" "django.shop.carticon_caption" %}
 
-{% if num_items %}
+{% if cart.num_items %}
 {% page_url 'shop-cart' as shop_cart_url %}
 {% page_attribute 'menu_title' 'shop-cart' as tooltip %}
 {% endif %}


### PR DESCRIPTION
This allows to launch django-shop without the fixtures, and blow can load the fixtures later for exemple: 

> [Django Smuggle](https://github.com/semente/django-smuggler)r is a pluggable application for Django Web Framework to easily dump/load fixtures via the automatically-generated administration interface. A fixture is file with model data serialized to e.g. JSON or XML that Django knows how to import to the database.