### PR TITLE
fix codeblocks syntax in tutorial/intro and reference/filters

### DIFF
--- a/docs/reference/filters.rst
+++ b/docs/reference/filters.rst
@@ -155,7 +155,7 @@ While rendering HTML pages, this extra context then can be used to render variou
 elements, such as a ``<select>``-box. Since our ``ProductFilter`` can be rendered as form fields,
 we just have to use this Django template:
 
-..code-block:: django
+.. code-block:: django
 
 	{{ filter.filter_set.form }}
 

--- a/docs/tutorial/intro.rst
+++ b/docs/tutorial/intro.rst
@@ -74,13 +74,13 @@ applications:
 
 Install some additional Python applications, globally or for the current user:
 
-.. code-block::
+.. code-block:: shell
 
 	pip install --user pipenv cookiecutter autopep8
 
 Then change into a directory, usually used for your projects and invoke:
 
-.. code-block::
+.. code-block:: shell
 
 	cookiecutter https://github.com/awesto/cookiecutter-django-shop
 
@@ -89,7 +89,7 @@ You will be asked a few question. If unsure, just use the defaults. This creates
 project into your *merchant implementation*. For simplicity, in this tutorial, it is refered as
 ``my-shop``. Change into this directory and install the missing dependencies:
 
-.. code-block::
+.. code-block:: shell
 
 	cd my-shop
 	pipenv install --sequential
@@ -99,13 +99,13 @@ This demo shop must initialize its database and be filled with content for demon
 Each of these steps can be performed individually, but for simplicity we use a Django managment
 command which wraps all these command into a single one:
 
-.. code-block::
+.. code-block:: shell
 
 	pipenv run ./manage.py initialize_shop_demo
 
 Finally we start the project, using Django's built-in development server:
 
-.. code-block::
+.. code-block:: shell
 
 	export DJANGO_DEBUG=1
 	pipenv run ./manage.py runserver


### PR DESCRIPTION
filters.rst was missing a space. The result was that a code block was not parsed as a code block but just as text.

intro.rst was missing the language specifier of the code block. While some rst viewers would still show the code blocks, sphinx seems to ignore such blocks. Thus the code was missing on [the corresponding read-the-docs page](https://django-shop.readthedocs.io/en/latest/tutorial/intro.html#installation). This PR should solve this (tested locally with `make singlehtml`)

Should fix #768