### PR TITLE
Fixes/778 two payment modifiers same processor

### DIFF
--- a/shop/payment/modifiers.py
+++ b/shop/payment/modifiers.py
@@ -35,7 +35,7 @@ class PaymentModifier(BaseCartModifier):
         :returns: ``True`` if this payment modifier is active.
         """
         assert hasattr(self, 'payment_provider'), "A Payment Modifier requires a Payment Provider"
-        return payment_modifier == self.payment_provider.namespace
+        return payment_modifier == self.identifier
 
     def is_disabled(self, cart):
         """

--- a/tests/test_cart.py
+++ b/tests/test_cart.py
@@ -9,6 +9,7 @@ from shop.models.cart import CartModel
 from shop.models.defaults.customer import Customer
 from shop.modifiers.pool import CartModifiersPool
 from shop.views.cart import CartViewSet, WatchViewSet
+from shop.modifiers.pool import cart_modifiers_pool
 from rest_framework.reverse import reverse
 
 CartModifiersPool.USE_CACHE = False
@@ -124,3 +125,11 @@ def test_include_tax_modifier(api_rf, filled_cart):
     assert response.data['subtotal'] == six.text_type(filled_cart.subtotal)
     tax_rate = 1 + app_settings.SHOP_VALUE_ADDED_TAX / 100
     assert response.data['total'] == six.text_type(filled_cart.subtotal * tax_rate)
+
+
+@pytest.mark.django_db
+def test_payment_modifiers_with_same_processors(api_rf, filled_cart):
+    for modifier_to_test in cart_modifiers_pool.get_payment_modifiers():
+        for modifier_for_id in cart_modifiers_pool.get_payment_modifiers():
+            if modifier_to_test.is_active(modifier_for_id.identifier):
+                assert modifier_for_id.identifier == modifier_to_test.identifier

--- a/tests/testshop/modifiers.py
+++ b/tests/testshop/modifiers.py
@@ -1,0 +1,9 @@
+from shop.payment.modifiers import PayInAdvanceModifier
+from django.utils.translation import ugettext_lazy as _
+
+
+class ComplexPayInAdvanceModifier(PayInAdvanceModifier):
+    identifier = "complex-pay-in-advance-modifier"
+    def get_choice(self):
+        return (self.identifier, _("Pay in advance with complex payment system X"))
+

--- a/tests/testshop/settings.py
+++ b/tests/testshop/settings.py
@@ -193,6 +193,7 @@ SHOP_CART_MODIFIERS = [
     'shop.modifiers.defaults.DefaultCartModifier',
     'shop.modifiers.taxes.CartIncludeTaxModifier',
     'shop.payment.modifiers.PayInAdvanceModifier',
+    'testshop.modifiers.ComplexPayInAdvanceModifier',
     'shop.shipping.modifiers.SelfCollectionModifier',
 ]
 


### PR DESCRIPTION
1. I added another payment modifier which uses the same payment provider as the PayInAdvanceModifier to the testshop.
2. I included the new `ComplexPayInAdvanceModifier` in the settings.py of the testshop. 
3. I provided a new Test that check the is_active function of all payment_modifiers
4. I wrote a fix for the PaymentModifier base implementation of is_active

Main change: `PaymentModifier:is_active` method now uses its `identifier` property instead of the namespace of its payment_provider. Since the default implementation of the `identifier`property returns the namespace of the `payment_provider`, in default cases this should not change a thing. If, however, `identity` is set to a specific value, (e.g. to be able to distinguish between pretty similar PaymentModifier objects) this identity is used.

should fix #778