### PR TITLE
add possiblity to overide `RegisterUserForm` for add other fields if it's necessary.

### DIFF
--- a/shop/cascade/auth.py
+++ b/shop/cascade/auth.py
@@ -17,7 +17,7 @@ AUTH_FORM_TYPES = [
     ('password-reset-request', _("Request Password Reset")),
     ('password-reset-confirm', _("Confirm Password Reset")),
     ('password-change', _("Change Password Form")),
-    ('register-user', _("Register User"), 'shop.forms.auth.RegisterUserForm'),
+    ('register-user', _("Register User"), app_settings.SHOP_CASCADE_FORMS['RegisterUserForm']),
     ('continue-as-guest', _("Continue as guest")),
 ]
 

--- a/shop/conf.py
+++ b/shop/conf.py
@@ -317,6 +317,7 @@ class DefaultSettings(object):
             'ShippingMethodForm': 'shop.forms.checkout.ShippingMethodForm',
             'ExtraAnnotationForm': 'shop.forms.checkout.ExtraAnnotationForm',
             'AcceptConditionForm': 'shop.forms.checkout.AcceptConditionForm',
+            'RegisterUserForm': 'shop.forms.auth.RegisterUserForm',
         }
         cascade_forms.update(self._setting('SHOP_CASCADE_FORMS', {}))
         return cascade_forms


### PR DESCRIPTION
Otherwise it is not possible to override `RegisterUserForm` without modifying the django-shop code.

