### PR TITLE
add optional attr `prev_cur_next_products` for `ProductRetrieveView`

### DIFF
--- a/shop/serializers/defaults/catalog.py
+++ b/shop/serializers/defaults/catalog.py
@@ -39,6 +39,8 @@ class AddToCartSerializer(serializers.Serializer):
     def __init__(self, instance=None, data=empty, **kwargs):
         context = kwargs.get('context', {})
         if 'product' in context:
+            if not hasattr( context['product'], 'product_code'):
+                context['product'].product_code = context['product'].variants.first().product_code
             instance = self.get_instance(context, data, kwargs)
             if data is not empty and 'quantity' in data:
                 quantity = self.fields['quantity'].to_internal_value(data['quantity'])

--- a/shop/serializers/defaults/catalog.py
+++ b/shop/serializers/defaults/catalog.py
@@ -78,11 +78,12 @@ class AddToCartSerializer(serializers.Serializer):
         except CartModel.DoesNotExist:
             cart = None
         extra = data.get('extra', {}) if data is not empty else {}
+        product_code = product.product_code if hasattr(product, 'product_code') else product.variants.first().product_code
         return {
             'product': product.id,
-            'product_code': product.product_code,
+            'product_code':product_code,
             'unit_price': product.get_price(request),
             'is_in_cart': bool(product.is_in_cart(cart)),
             'extra': extra,
-            'availability': product.get_availability(request, **extra),
+            'availability': product.get_availability(request, product_code=product_code, **extra) ,
         }

--- a/shop/templates/shop/catalog/product-detail-ext.html
+++ b/shop/templates/shop/catalog/product-detail-ext.html
@@ -1,0 +1,56 @@
+{% extends "shop/catalog/product-detail.html" %}
+{% load i18n cms_tags thumbnail %}
+
+{% block main-content %}
+{% thumbnail product.images.first 250x250 crop as thumb %}
+<div class="container">
+	<div class="row">
+		<div  class="col-1 col-sm-2 text-center " style="padding-top:20%;">
+		{% if  productprev %}
+			<a  id="productprev" class=" text-muted"  alt="Previous" title="{{ productprev }}" href="{{ productprev.slug }}">
+				{% thumbnail productprev.images.first 100x100 crop as thumb_prev %}
+				<img class="d-none d-lg-block mx-auto" style="opacity: 0.9;" src="{{ thumb_prev.url }}" width="{{ thumb_prev.width }}" height="{{ thumb_prev.height }}" alt="{{ productprev.product_name }}">
+				<p id="productprev" class="fa fa-angle-left fa-2x fleche-size text-muted" style="text-decoration: none;" alt="Previous" title="{{ productprev }}" href="{{ productprev.slug }}"></p>
+				<div class="d-none d-lg-block">{{ productprev.product_name }}</div>
+			</a>
+		{% endif %}
+		</div>
+		<div class="col col-md-8">
+			<h1>{% render_model product "product_name" %}</h1>
+			<div class="media mb-3 flex-column flex-md-row">
+				<img class="mr-3 mb-3" src="{{ thumb.url }}" width="{{ thumb.width }}" height="{{ thumb.height }}" alt="{{ product.product_name }}">
+				<div class="media-body">
+					{{ product.description|safe }}
+				</div>
+			</div>
+			<h4>{% trans "Details" %}</h4>
+			<ul class="list-group mb-3">
+				<li class="list-group-item d-flex">
+					<div class="w-50">{% trans "Card Type" %}:</div>
+					<strong>{{ product.get_card_type_display }}</strong>
+				</li>
+				<li class="list-group-item d-flex">
+					<div class="w-50">{% trans "Storage capacity" %}:</div>
+					<strong>{{ product.storage }} GB</strong>
+				</li>
+				<li class="list-group-item d-flex">
+					<div class="w-50">{% trans "Manufacturer" %}:</div>
+					<strong>{{ product.manufacturer }}</strong>
+				</li>
+			</ul>
+			<!-- include "Add to Cart" dialog box -->
+			{% include "shop/catalog/available-product-add2cart.html" with card_css_classes="mb-3" %}
+		</div>
+		{% if productnext %}
+		<div class="col-1 col-sm-2 text-center" style="padding-top:20%;">
+			<a id="productnext" class="text-muted"  alt="Next" title="{{ productnext}}" href="{{ productnext.slug }}">
+				{% thumbnail productnext.images.first 100x100 crop as thumb_next %}
+				<img class="d-none d-lg-block mx-auto" style="opacity: 0.9;" src="{{ thumb_next.url }}" width="{{ thumb_next.width }}" height="{{ thumb_next.height }}" alt="{{ productnext.product_name }}">
+				<p id="productnext" class="fa fa-angle-right fa-2x fleche-size text-muted" style="text-decoration: none;" alt="Next" title="{{ productnext}}" href="{{ productnext.slug }}"></p>
+				<div class="d-none d-lg-block">{{ productnext.product_name }}</div>
+			</a>
+		{% endif %}
+		</div>
+	</div>
+</div>
+{% endblock main-content %}

--- a/shop/views/catalog.py
+++ b/shop/views/catalog.py
@@ -323,6 +323,8 @@ class ProductRetrieveView(generics.RetrieveAPIView):
         renderer_context = super(ProductRetrieveView, self).get_renderer_context()
         if renderer_context['request'].accepted_renderer.format == 'html':
             # add the product as Python object to the context
+            if not hasattr(product ,'_meta'):
+                product._meta = product.variants.first()._meta
             if hasattr(self, 'prev_cur_next_products') and self.prev_cur_next_products:
                 product__prev,  product ,product__next = self.get_objects_prev_cur_next()
                 renderer_context.update(

--- a/shop/views/catalog.py
+++ b/shop/views/catalog.py
@@ -368,8 +368,8 @@ class ProductRetrieveView(generics.RetrieveAPIView):
             filter_slug = filter_kwargs['slug']
             filter_kwargs.pop('slug')
             queryset = self.product_model.objects.filter(self.limit_choices_to, **filter_kwargs)
-            qs = queryset.select_related('polymorphic_ctype')
-            qs = CMSPagesFilterBackend().filter_queryset(self.request, qs, self)
+            #qs = queryset.select_related('polymorphic_ctype')
+            qs = CMSPagesFilterBackend().filter_queryset(self.request, queryset, self)
             self._product__prev, self._product, self._product__next = self.prev_cur_next_category(qs ,filter_slug)
         return  self._product__prev, self._product, self._product__next
 

--- a/shop/views/catalog.py
+++ b/shop/views/catalog.py
@@ -313,7 +313,7 @@ class ProductRetrieveView(generics.RetrieveAPIView):
         ]
 
     def get_template_names(self):
-        if hasattr(self, 'prev_cur_next_products'):
+        if hasattr(self, 'prev_cur_next_products') and self.prev_cur_next_products:
             templates_path = self.format_templates_path('detail-ext')
         else:
             templates_path = self.format_templates_path('detail')
@@ -323,7 +323,7 @@ class ProductRetrieveView(generics.RetrieveAPIView):
         renderer_context = super(ProductRetrieveView, self).get_renderer_context()
         if renderer_context['request'].accepted_renderer.format == 'html':
             # add the product as Python object to the context
-            if hasattr(self, 'prev_cur_next_products'):
+            if hasattr(self, 'prev_cur_next_products') and self.prev_cur_next_products:
                 product__prev,  product ,product__next = self.get_objects_prev_cur_next()
                 renderer_context.update(
                     app_label=product._meta.app_label.lower(),

--- a/shop/views/catalog.py
+++ b/shop/views/catalog.py
@@ -323,10 +323,10 @@ class ProductRetrieveView(generics.RetrieveAPIView):
         renderer_context = super(ProductRetrieveView, self).get_renderer_context()
         if renderer_context['request'].accepted_renderer.format == 'html':
             # add the product as Python object to the context
-            if not hasattr(product ,'_meta'):
-                product._meta = product.variants.first()._meta
             if hasattr(self, 'prev_cur_next_products') and self.prev_cur_next_products:
                 product__prev,  product ,product__next = self.get_objects_prev_cur_next()
+                if not hasattr(product ,'_meta'):
+                    product._meta = product.variants.first()._meta
                 renderer_context.update(
                     app_label=product._meta.app_label.lower(),
                     product=product,

--- a/shop/views/catalog.py
+++ b/shop/views/catalog.py
@@ -325,7 +325,7 @@ class ProductRetrieveView(generics.RetrieveAPIView):
             # add the product as Python object to the context
             if hasattr(self, 'prev_cur_next_products') and self.prev_cur_next_products:
                 product__prev,  product ,product__next = self.get_objects_prev_cur_next()
-                if not hasattr(product ,'_meta'):
+                if product and not hasattr(product ,'_meta'):
                     product._meta = product.variants.first()._meta
                 renderer_context.update(
                     app_label=product._meta.app_label.lower(),

--- a/shop/views/catalog.py
+++ b/shop/views/catalog.py
@@ -273,6 +273,7 @@ class ProductRetrieveView(generics.RetrieveAPIView):
     serializer_class = ProductSerializer
     limit_choices_to = models.Q()
     use_modal_dialog = True
+    prev_cur_next_products = False
 
     def dispatch(self, request, *args, **kwargs):
         """

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -34,7 +34,7 @@ djangocms-admin-style==1.3.0
 djangocms-bootstrap==1.1.2
 djangocms-cascade==1.1.9
 djangocms-text-ckeditor==3.8.0
-djangorestframework==3.11.0
+djangorestframework==3.9.3
 drf-haystack==1.8.4
 easy-thumbnails==2.6
 elasticsearch==1.7.0

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -32,6 +32,17 @@ def test_catalog_detail(commodity_factory, customer_factory, rf):
     assert response.data['price'] == six.text_type(product.unit_price)
     assert response.data['slug'] == product.slug
 
+@pytest.mark.django_db
+def test_catalog_detail_ext(commodity_factory, customer_factory, rf):
+    product = commodity_factory()
+    request = rf.get('/catalog/{}'.format(product.slug))
+    request.current_page = product.cms_pages.first()
+    request.customer = customer_factory()
+    response = ProductRetrieveView.as_view(prev_cur_next_products=True)(request, slug=product.slug)
+    response.render()
+    assert response.data['product_code'] == product.product_code
+    assert response.data['price'] == six.text_type(product.unit_price)
+    assert response.data['slug'] == product.slug
 
 @pytest.mark.django_db
 def test_get_add_to_cart(commodity_factory, customer_factory, rf):


### PR DESCRIPTION
related #734 
![Peek 14-03-2020 15-19](https://user-images.githubusercontent.com/344493/76683847-6c89dd00-6607-11ea-8d6d-8c1b4ff4091c.gif)

with django-shop1.2 and polymorphic and  djangorestframework==3.9.2:
With `prev_cur_next_products = False`, it  finds `product.product_code` with SmartPhoneModel,   SmartCard, Commodity.
but:
`With prev_cur_next_products = True`, there is a bug when i try view with product SmartPhoneModel, it does not find the `product.product_code`, whereas it finds it for SmartCard, Commodity.
(Currently not available)
![Capture d’écran du 2020-03-14 15-32-30](https://user-images.githubusercontent.com/344493/76684092-4f560e00-6609-11ea-8dd0-1f011973b419.jpg)

backoffice error:
```
  File "/python3.8/site-packages/django/core/handlers/exception.py", line 34, in inner
    response = get_response(request)
  File "/python3.8/site-packages/django/core/handlers/base.py", line 115, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/python3.8/site-packages/django/core/handlers/base.py", line 113, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/python3.8/site-packages/cms/utils/decorators.py", line 20, in inner
    return func(request, *args, **kwargs)
  File "/python3.8/site-packages/django/views/decorators/csrf.py", line 54, in wrapped_view
    return view_func(*args, **kwargs)
  File "/python3.8/site-packages/django/views/generic/base.py", line 71, in view
    return self.dispatch(request, *args, **kwargs)
  File "/python3.8/site-packages/rest_framework/views.py", line 495, in dispatch
    response = self.handle_exception(exc)
  File "/python3.8/site-packages/rest_framework/views.py", line 455, in handle_exception
    self.raise_uncaught_exception(exc)
  File "/python3.8/site-packages/rest_framework/views.py", line 492, in dispatch
    response = handler(request, *args, **kwargs)
  File "/haricot/.cache/pypoetry/virtualenvs/my-shop-et1pgCPw-py3.8/src/django-shop/shop/views/catalog.py", line 225, in get
    serializer = self.serializer_class(context=context, **kwargs)
  File "/haricot/.cache/pypoetry/virtualenvs/my-shop-et1pgCPw-py3.8/src/django-shop/shop/serializers/defaults/catalog.py", line 46, in __init__
    instance = self.get_instance(context, data, kwargs)
  File "/haricot/.cache/pypoetry/virtualenvs/my-shop-et1pgCPw-py3.8/src/django-shop/shop/serializers/defaults/catalog.py", line 92, in get_instance
    'product_code': product.product_code,
```
