### PR TITLE
 Fix bug, Wrong exception

### DIFF
--- a/shop/cascade/catalog.py
+++ b/shop/cascade/catalog.py
@@ -163,7 +163,7 @@ class ShopProductGallery(WithSortableInlineElementsMixin, ShopPluginBase):
         for inline in instance.sortinline_elements.all():
             try:
                 product_ids.append(inline.glossary['product']['pk'])
-            except KeyError:
+            except TypeError:
                 pass
         queryset = ProductModel.objects.filter(pk__in=product_ids, active=True)
         serializer_class = app_settings.PRODUCT_SUMMARY_SERIALIZER


### PR DESCRIPTION
Error deleting an item from the image gallery catalog :

```
TypeError at /es/
'NoneType' object is not subscriptable
Request Method:	GET
Request URL:	http://localhost:8000/es/
Django Version:	3.0.7
Exception Type:	TypeError
Exception Value:	
'NoneType' object is not subscriptable
Exception Location:	/home/kira/.virtualenvs/vsite/lib/python3.6/site-packages/shop/cascade/catalog.py in render, line 165
Python Executable:	/home/kira/.virtualenvs/vsite/bin/python
Python Version:	3.6.0
Python Path:	
['/home/kira/Desarrollo/implementacion/vsite',
 '/home/kira/Desarrollo/implementacion/vsite',
 '/home/kira/Desarrollo/ide/pycharm-2020.1.1/plugins/python/helpers/pycharm_display',
 '/home/kira/.pyenv/versions/3.6.0/lib/python36.zip',
 '/home/kira/.pyenv/versions/3.6.0/lib/python3.6',
 '/home/kira/.pyenv/versions/3.6.0/lib/python3.6/lib-dynload',
 '/home/kira/.virtualenvs/vsite/lib/python3.6/site-packages',
 '/home/kira/Desarrollo/ide/pycharm-2020.1.1/plugins/python/helpers/pycharm_matplotlib_backend']
Server time:	Mar, 23 Jun 2020 15:09:03 +0000
```
Correct exception type is TypeError