### PR TITLE
changed caching behavior

### DIFF
--- a/shop/models/product.py
+++ b/shop/models/product.py
@@ -4,7 +4,8 @@ from urllib.parse import urljoin
 
 from django.apps import apps
 from django.conf import settings
-from django.core import cache, checks
+from django.core import checks
+from django.core.cache import cache
 from django.db import models
 from django.db.models.aggregates import Sum
 from django.db.models.functions import Coalesce
@@ -370,7 +371,7 @@ class BaseProduct(PolymorphicModel, metaclass=PolymorphicProductMetaclass):
         """
         shop_app = apps.get_app_config('shop')
         if shop_app.cache_supporting_wildcard:
-            cache.delete_pattern('product:{}|*'.format(self.id))
+            cache.delete('product:{}|*'.format(self.id))
 
 ProductModel = deferred.MaterializedModel(BaseProduct)
 


### PR DESCRIPTION
I just setup my shop together with `django-redis-cache` package and I got an error, when changing a model, when it wanted to invalidate mny 
So I adapted the code in `product.py` to use Django caching API's `delete(key)`.

See: https://docs.djangoproject.com/en/3.0/topics/cache/#django.core.caches.cache.delete