### PR TITLE
enable pagination for search results

### DIFF
--- a/shop/search/mixins.py
+++ b/shop/search/mixins.py
@@ -57,4 +57,6 @@ class CatalogSearchViewMixin(SearchViewMixin):
         search = document.search().source(excludes=['body'])
         if query:
             search = search.query('multi_match', query=query, fields=self.search_fields)
+            #otherwise only 10 products will be returned and there will be no pagination
+            search = search[0:search.count()]  
         return search.to_queryset()


### PR DESCRIPTION
I encountered the problem, that there where always 10 results in my search-results-page. So I read the elasticsearch-dsl documentation and it stated, that elasticsearch always returns only 10 results at a time.

To paginate we would have to use python slice operator, but as pagination is done in the front-end, I return all the results by using `search = search[0:search.count()]` and then using `search.to_queryset()` which will result in a queryset containing all results found at a time.

Then the front-end is able to also paginate and show more than 10 results.