### PR TITLE
Update setup.py to prevent installing v2.0 of djangocms-cascade

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ REQUIREMENTS = [
     'django_polymorphic',
     'django-post_office',
     'django-cms>=3.7',
-    'djangocms-cascade>=1.3',
+    'djangocms-cascade>=1.3,<2',
 ]
 
 CLASSIFIERS = [


### PR DESCRIPTION
@jrief the recent update of https://github.com/jrief/djangocms-cascade requires Django>=3.1, whereas django-shop 1.2.3 requires Django<3.1 (line 9 below).

This PR simply prevents the 2.0 version from being installed. When this change is not made, there will be a VERSION NOT FOUND ERROR
```
ERROR: Could not find a version that matches django<3.1,<3.2,<4.0,>=1.6,>=1.8,>=1.8.0,>=2.0,>=2.1,>=2.2,>=3.1
```

```
  django<3.1,>=2.1 (from django-shop==1.2.3->-r /var/folders/yb/4bmdr0l927n7zk6m_jdfq4p00000gp/T/pipenvgrarsd7mrequirements/pipenv-ydxt677t-constraints.txt (line 17))
  django>=3.1 (from djangocms-cascade==2.0->-r /var/folders/yb/4bmdr0l927n7zk6m_jdfq4p00000gp/T/pipenvgrarsd7mrequirements/pipenv-ydxt677t-constraints.txt (line 18))
```