### PR TITLE
Fixed missing phone number in Django Shop Plugin

### DIFF
--- a/shop/cascade/plugin_base.py
+++ b/shop/cascade/plugin_base.py
@@ -52,7 +52,8 @@ class CatalogLinkForm(LinkForm):
         ('exturl', _("External URL")),
         ('email', _("Mail To")),
     ]
-
+    if PhoneNumberField:
+        LINK_TYPE_CHOICES.append(('phonenumber', _("Phone number")))
     product = ProductSelectField(
         label=_("Product"),
         required=False,


### PR DESCRIPTION
Missing phone number option in link plugin #861 Django Shop plugin is missing due to overriding the LinkForm.LINK_TYPE_CHOICES property. By letting add to LinkForm if the phone number exists.