### PR TITLE
Fix: Date value out of range when changing default TIME_ZONE variable  to another value

### DIFF
--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -7,6 +7,7 @@ import pytest
 from pytest_factoryboy import register
 from conftest import CommodityFactory
 from testshop.models import MyProduct, MyProductInventory
+import datetime
 
 
 class MyProductFactory(CommodityFactory):
@@ -21,8 +22,11 @@ class InventoryFactory(factory.django.DjangoModelFactory):
 
     product = factory.SubFactory(MyProductFactory)
 
-datetime_min = timezone.datetime.min.replace(tzinfo=timezone.get_current_timezone())
-datetime_max = timezone.datetime.max.replace(tzinfo=timezone.get_current_timezone())
+
+datetime_min = timezone.datetime.min.replace(
+    tzinfo=timezone.get_current_timezone()) + datetime.timedelta(weeks=1)
+datetime_max = timezone.datetime.max.replace(
+    tzinfo=timezone.get_current_timezone()) - datetime.timedelta(weeks=1)
 
 
 @pytest.mark.django_db
@@ -59,7 +63,8 @@ def test_limited_offer(api_rf, inventory_factory):
     now = timezone.now()
     earliest = now
     latest = now + app_settings.SHOP_LIMITED_OFFER_PERIOD / 2
-    inventory = inventory_factory(earliest=earliest, latest=latest, quantity=10)
+    inventory = inventory_factory(
+        earliest=earliest, latest=latest, quantity=10)
     availability = inventory.product.get_availability(request)
     assert availability.quantity == 10
     assert availability.earliest == earliest


### PR DESCRIPTION
 For example, when changing the value of TIME_ZONE="America/Caracas" in the configuration file (testshop/settings.py), the following error is reported when running the tests:

![ArcoLinux_2023-10-18_20-25-48](https://github.com/awesto/django-shop/assets/1105101/aec3b9bd-154d-403d-8673-1964c16f30b5)

My solution is to increase the minimum date by 1 week and decrease the maximum date by 1 week, this way when they change the TIME_ZONE value it doesn't run a date out of range error. By applying this solution you can verify that all tests were satisfactory:

![ArcoLinux_2023-10-18_20-30-51](https://github.com/awesto/django-shop/assets/1105101/bc8c479a-43b8-40f2-bcde-3570370b0f62)


* Note: code formatted in PEP-8 style